### PR TITLE
Remove useless heuristic call for astar

### DIFF
--- a/src/directed/astar.rs
+++ b/src/directed/astar.rs
@@ -93,7 +93,7 @@ where
 {
     let mut to_see = BinaryHeap::new();
     to_see.push(SmallestCostHolder {
-        estimated_cost: heuristic(start),
+        estimated_cost: Zero::zero(),
         cost: Zero::zero(),
         index: 0,
     });
@@ -184,7 +184,7 @@ where
     let mut min_cost = None;
     let mut sinks = HashSet::new();
     to_see.push(SmallestCostHolder {
-        estimated_cost: heuristic(start),
+        estimated_cost: Zero::zero(),
         cost: Zero::zero(),
         index: 0,
     });


### PR DESCRIPTION
Since the SmallestCostHolder for the start value is the only value in the heap, it will be popped directly, so heuristic doesn't have to be called. 
However since FH is FnMut, this is a breaking change..