### PR TITLE
(3-line-change PR) allow f32/f64 to be used in kruskal algorithm as weights (following official sort_by example)

### DIFF
--- a/src/undirected/kruskal.rs
+++ b/src/undirected/kruskal.rs
@@ -50,13 +50,13 @@ pub fn kruskal_indices<C>(
     edges: &[(usize, usize, C)],
 ) -> impl Iterator<Item = (usize, usize, C)>
 where
-    C: Clone + Ord,
+    C: Clone + PartialOrd,
 {
     let mut parents = (0..number_of_nodes).collect::<Vec<_>>();
     let mut ranks = Vec::with_capacity(number_of_nodes);
     ranks.resize(number_of_nodes, 1);
     let mut edges = edges.to_vec();
-    edges.sort_by(|a, b| a.2.cmp(&b.2));
+    edges.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
     edges.into_iter().filter_map(move |(a, b, w)| {
         let ra = find(&mut parents, a);
         let rb = find(&mut parents, b);
@@ -75,7 +75,7 @@ where
 pub fn kruskal<N, C>(edges: &[(N, N, C)]) -> impl Iterator<Item = (N, N, C)>
 where
     N: Clone + Hash + Eq,
-    C: Clone + Ord,
+    C: Clone + PartialOrd,
 {
     let mut nodes = IndexSet::new();
     let edges = edges


### PR DESCRIPTION
official sort_by example: https://doc.rust-lang.org/std/primitive.slice.html#method.sort_by