### PR TITLE
feat(matrix): implement DoubleEndedIterator for RowIterator

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -803,6 +803,16 @@ impl<'a, C> Iterator for RowIterator<'a, C> {
     }
 }
 
+impl<'a, C> DoubleEndedIterator for RowIterator<'a, C> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        (self.row < self.matrix.rows).then(|| {
+            let row = self.matrix.rows - self.row;
+            self.row += 1;
+            &self.matrix.data[(row - 1) * self.matrix.columns..row * self.matrix.columns]
+        })
+    }
+}
+
 impl<C> FusedIterator for RowIterator<'_, C> {}
 
 impl<'a, C> IntoIterator for &'a Matrix<C> {

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -541,6 +541,14 @@ fn iter() {
 }
 
 #[test]
+fn iter_back() {
+    let m = matrix![[0, 1, 2], [3, 4, 5], [6, 7, 8]];
+    let mut forward = m.iter().collect::<Vec<_>>();
+    forward.reverse();
+    assert_eq!(forward, m.iter().rev().collect::<Vec<_>>());
+}
+
+#[test]
 fn into_iter() {
     let m = matrix![[0, 1, 2], [2, 1, 0], [1, 0, 2]];
     for c in &m {


### PR DESCRIPTION
This allows using `matrix.iter().rev()` to handle rows in reverse order.
