### PR TITLE
feat(matrix): add in-place matrix transposition for non-square matrix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ rustc-hash = "1.1.0"
 integer-sqrt = "0.1.5"
 thiserror = "1.0.56"
 deprecate-until = "0.1.1"
+bitvec = "1.0.1"
+# wyz and tap needed to force minimal compatible versions
+# for bitvec inclusion
+wyz = "0.5.1"
+tap = "1.0.1"
 
 [dev-dependencies]
 codspeed-criterion-compat = "1.1.0"

--- a/benches/matrices.rs
+++ b/benches/matrices.rs
@@ -10,5 +10,14 @@ pub fn transpose_benchmark(c: &mut Criterion) {
     c.bench_function("transpose", |b| b.iter(|| m.transpose()));
 }
 
-criterion_group!(benches, transpose_benchmark);
+#[allow(clippy::missing_panics_doc)]
+pub fn transpose_non_square_benchmark(c: &mut Criterion) {
+    // Generate a 1000 x 10 square matrix with entries from 1 to 100^2
+    let data: Vec<i32> = (0..100 * 100).collect();
+    let mut m = Matrix::from_vec(1000, 10, data).unwrap();
+
+    c.bench_function("transpose_non_square", |b| b.iter(|| m.transpose()));
+}
+
+criterion_group!(benches, transpose_benchmark, transpose_non_square_benchmark);
 criterion_main!(benches);

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -235,10 +235,14 @@ fn transpose_in_place() {
 }
 
 #[test]
-#[should_panic(expected = "attempt to transpose a non-square matrix")]
-fn transpose_in_place_panic() {
+fn transpose_in_place_non_square() {
+    let mut m = matrix![[0, 1, 2]];
+    m.transpose();
+    assert_eq!(m, matrix![[0], [1], [2]]);
+
     let mut m = matrix![[0, 1, 2], [3, 4, 5]];
     m.transpose();
+    assert_eq!(m, matrix![[0, 3], [1, 4], [2, 5]]);
 }
 
 fn sum(slice: &[usize]) -> usize {


### PR DESCRIPTION
Close https://github.com/evenfurther/pathfinding/issues/497.

I took a stab at the most basic implementation described in https://en.wikipedia.org/wiki/In-place_matrix_transposition. There are definitely more optimal approaches given the references from that page, as this requires MN additional memory for recording visited locations.

Given the added complexity and memory, would it be preferable to fork the logic here for square vs non-square matrices? 