### PR TITLE
fix(deps): add priority to clippy lints for lint_groups_priority

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ trybuild = "1.0.89"
 version_check = "0.9.4"
 
 [lints.clippy]
-pedantic = "deny"
-module_name_repetitions = "allow"
+module_name_repetitions = { level = "allow", priority = 1 }
+pedantic = { level = "deny", priority = 0 }
 
 [[bench]]
 name = "algos"


### PR DESCRIPTION
They added a [lint_groups_priority](https://github.com/rust-lang/rust-clippy/pull/11832) check last week that caused [this failure in CI](https://github.com/evenfurther/pathfinding/actions/runs/7853251283/job/21432650495#step:5:170).

```
error: lint group `pedantic` has the same priority (0) as a lint
  --> Cargo.toml:53:1
   |
53 | pedantic = "deny"
   | ^^^^^^^^   ------ has an implicit priority of 0
54 | module_name_repetitions = "allow"
   | ----------------------- has the same priority as this lint
   |
   = note: the order of the lints in the table is ignored by Cargo
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#lint_groups_priority
   = note: `#[deny(clippy::lint_groups_priority)]` on by default
help: to have lints override the group set `pedantic` to a lower priority
   |
53 | pedantic = { level = "deny", priority = -1 }
   |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Adding explicit priorities to the clippy lint rules resolves this check. I think previous CI was passing because of cached clippy versions from before `v0.1.78` was released. 