### PR TITLE
fix(matrix): use bitvec-rs instead of bitvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,7 @@ rustc-hash = "1.1.0"
 integer-sqrt = "0.1.5"
 thiserror = "1.0.56"
 deprecate-until = "0.1.1"
-bitvec = "1.0.1"
-# wyz and tap needed to force minimal compatible versions
-# for bitvec inclusion
-wyz = "0.6.1"
-tap = "1.0.1"
+bitvec-rs = "0.2.1"
 
 [dev-dependencies]
 codspeed-criterion-compat = "1.1.0"

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -3,7 +3,7 @@
 use crate::directed::bfs::bfs_reach;
 use crate::directed::dfs::dfs_reach;
 use crate::utils::{constrain, in_direction, move_in_direction, uint_sqrt};
-use bitvec::prelude::bitvec;
+use bitvec_rs::BitVec;
 use deprecate_until::deprecate_until;
 use num_traits::Signed;
 use std::collections::BTreeSet;
@@ -728,7 +728,7 @@ impl<C> Matrix<C> {
         let mn1 = m * n - 1;
 
         // Scratch array for recording visited locations
-        let mut visited = bitvec![0; m * n];
+        let mut visited = BitVec::from_elem(m * n, false);
 
         for s in 1..self.data.len() {
             if visited[s] {


### PR DESCRIPTION
bitvec-rs is more efficient than bitvec. Also, it does not force us to add
phantom dependencies to work with `cargo update -Zminimal-versions`.
