### PR TITLE
fix(astar): Ord impl on SmallestCostHolder was half backward

### DIFF
--- a/src/directed/astar.rs
+++ b/src/directed/astar.rs
@@ -324,7 +324,7 @@ impl<K: Ord> PartialOrd for SmallestCostHolder<K> {
 impl<K: Ord> Ord for SmallestCostHolder<K> {
     fn cmp(&self, other: &Self) -> Ordering {
         match other.estimated_cost.cmp(&self.estimated_cost) {
-            Ordering::Equal => self.cost.cmp(&other.cost),
+            Ordering::Equal => other.cost.cmp(&self.cost),
             s => s,
         }
     }

--- a/tests/pathfinding.rs
+++ b/tests/pathfinding.rs
@@ -206,7 +206,7 @@ mod ex2 {
         .expect("path not found");
         assert_eq!(cost, 8);
         assert!(path.iter().all(|&(nx, ny)| OPEN[ny][nx]));
-        assert_eq!(counter, 11);
+        assert_eq!(counter, 14);
     }
 
     #[test]


### PR DESCRIPTION
The `Ord` is implemented on `SmallestCostHolder` backward so the heap becomes a min-heap, except that `SmallestCostHolder::cost` wasn't compared backward.
I think this is a bug but maybe I'm not seeing something and it's intentional, I'm not sure.
One test case also needs to be fixed if this is a bug, which this PR does too.