### PR TITLE
feat(prim): add Prim's algorithm for finding MST

### DIFF
--- a/src/undirected/mod.rs
+++ b/src/undirected/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod connected_components;
 pub mod kruskal;
+pub mod prim;

--- a/src/undirected/prim.rs
+++ b/src/undirected/prim.rs
@@ -5,14 +5,13 @@ use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashSet};
 use std::hash::Hash;
 
-
 /// Find a minimum-spanning-tree. From a collection of
 /// weighted edges, return a vector of edges forming
 /// a minimum-spanning-tree.
 pub fn prim<N, C>(edges: &[(N, N, C)]) -> impl Iterator<Item = (&N, &N, C)>
 where
     N: Hash + Eq + Ord,
-    C: Clone + Ord
+    C: Clone + Ord,
 {
     let mut mst: Vec<(&N, &N, C)> = Vec::new();
     if edges.is_empty() {

--- a/src/undirected/prim.rs
+++ b/src/undirected/prim.rs
@@ -1,0 +1,50 @@
+//! Find minimum-spanning-tree in an undirected graph using
+//! [Prim's algorithm](https://en.wikipedia.org/wiki/Prim%27s_algorithm).
+
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashSet};
+use std::hash::Hash;
+
+
+/// Find a minimum-spanning-tree. From a collection of
+/// weighted edges, return a vector of edges forming
+/// a minimum-spanning-tree.
+pub fn prim<N, C>(edges: &[(N, N, C)]) -> impl Iterator<Item = (&N, &N, C)>
+where
+    N: Hash + Eq + Ord,
+    C: Clone + Ord
+{
+    let mut mst: Vec<(&N, &N, C)> = Vec::new();
+    if edges.is_empty() {
+        return mst.into_iter();
+    }
+
+    let mut priority_queue = BinaryHeap::new();
+    let start = &edges[0].0;
+
+    for (n, n1, c) in edges {
+        if n == start {
+            priority_queue.push(Reverse((c, n, n1)));
+        }
+    }
+
+    let mut visited = HashSet::new();
+    visited.insert(start);
+    while let Some(Reverse((c, n, n1))) = priority_queue.pop() {
+        if visited.contains(n1) {
+            continue;
+        }
+
+        mst.push((n, n1, c.clone()));
+
+        for (n2, n3, c) in edges {
+            if n1 == n2 && !visited.contains(n3) {
+                priority_queue.push(Reverse((c, n1, n3)));
+            } else if n1 == n3 && !visited.contains(n2) {
+                priority_queue.push(Reverse((c, n1, n2)));
+            }
+        }
+        visited.insert(n1);
+    }
+    mst.into_iter()
+}

--- a/tests/prim.rs
+++ b/tests/prim.rs
@@ -1,0 +1,83 @@
+use pathfinding::undirected::prim::prim;
+
+#[test]
+// Simple example taken from the test used in kruskal implementation
+fn base_test() {
+    let edges = vec![
+        ('a', 'b', 3),
+        ('a', 'e', 1),
+        ('b', 'c', 5),
+        ('b', 'e', 4),
+        ('c', 'd', 2),
+        ('c', 'e', 6),
+        ('d', 'e', 7),
+    ];
+    assert_eq!(
+        prim(&edges).collect::<Vec<_>>(),
+        vec![
+            (&'a', &'e', 1),
+            (&'a', &'b', 3),
+            (&'b', &'c', 5),
+            (&'c', &'d', 2),
+        ]
+    );
+}
+
+#[test]
+// Taken from https://www.geeksforgeeks.org/prims-minimum-spanning-tree-mst-greedy-algo-5/
+fn geeksforgeeks() {
+    let edges = vec![
+        (0, 1, 4),
+        (0, 7, 8),
+        (1, 2, 8),
+        (1, 7, 11),
+        (2, 3, 7),
+        (2, 5, 4),
+        (2, 8, 2),
+        (3, 4, 9),
+        (3, 5, 14),
+        (4, 5, 10),
+        (5, 6, 2),
+        (6, 7, 1),
+        (6, 8, 6),
+        (7, 8, 7),
+    ];
+    assert_eq!(
+        prim(&edges).collect::<Vec<_>>(),
+        vec![
+            (&0, &1, 4),
+            (&0, &7, 8),
+            (&7, &6, 1),
+            (&6, &5, 2),
+            (&5, &2, 4),
+            (&2, &8, 2),
+            (&2, &3, 7),
+            (&3, &4, 9),
+        ]
+    );
+}
+
+// Order of edges is not important in the result, except for starting edge, because always
+// starting vertex of the first edge will be selected as the start in algorithm
+#[test]
+fn another_test() {
+    let edges = vec![
+        ('B', 'C', 10),
+        ('B', 'D', 4),
+        ('C', 'D', 2),
+        ('A', 'C', 3),
+        ('C', 'D', 2),
+        ('D', 'E', 1),
+        ('C', 'E', 6),
+        ('D', 'E', 1),
+    ];
+    assert_eq!(
+        prim(&edges).collect::<Vec<_>>(),
+        vec![
+            (&'B', &'D', 4),
+            (&'D', &'E', 1),
+            (&'D', &'C', 2),
+            (&'C', &'A', 3),
+        ]
+    );
+}


### PR DESCRIPTION
This a try to implement Prim's algorithm that is useful to find minimum spanning tree for an undirected graph.
For some cases, specially when the graph is dense, Prim is more efficient than Kruskal

After successful merge of this PR, issue #576 can be closed 