### PR TITLE
chore(Cargo.toml): allow `clippy::too_long_first_doc_paragraph`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ version_check = "0.9.4"
 
 [lints.clippy]
 module_name_repetitions = { level = "allow", priority = 1 }
+too_long_first_doc_paragraph = { level = "allow", priority = 1 } # Temporary
 pedantic = { level = "deny", priority = 0 }
 
 [[bench]]


### PR DESCRIPTION
This is necessary until the lint gets fixed to not handle hyperlinks as pure text and count towards the characters limit.