### PR TITLE
fix!(msrv): update MSRV to 1.77.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Samuel Tardieu <sam@rfc1149.net>"]
 categories = ["algorithms"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.74.0"
+rust-version = "1.77.2"
 
 [package.metadata.release]
 sign-commit = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //! in this context, you can wrap them into compliant types using the
 //! [ordered-float](https://crates.io/crates/ordered-float) crate.
 //!
-//! The minimum supported Rust version (MSRV) is Rust 1.74.0.
+//! The minimum supported Rust version (MSRV) is Rust 1.77.2.
 //!
 //! [A*]: https://en.wikipedia.org/wiki/A*_search_algorithm
 //! [BFS]: https://en.wikipedia.org/wiki/Breadth-first_search


### PR DESCRIPTION
This release of Rust includes a fix for CVE-2024-24576. It also allows a more recent of codspeed-criterion-compat to be used for measuring performance gains and losses.