### PR TITLE
feat: accept `&(usize, usize)` as `Matrix` index

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -787,10 +787,25 @@ impl<C> Index<(usize, usize)> for Matrix<C> {
     }
 }
 
+impl<C> Index<&(usize, usize)> for Matrix<C> {
+    type Output = C;
+
+    #[must_use]
+    fn index(&self, index: &(usize, usize)) -> &C {
+        &self[*index]
+    }
+}
+
 impl<C> IndexMut<(usize, usize)> for Matrix<C> {
     fn index_mut(&mut self, index: (usize, usize)) -> &mut C {
         let i = self.idx(index);
         &mut self.data[i]
+    }
+}
+
+impl<C> IndexMut<&(usize, usize)> for Matrix<C> {
+    fn index_mut(&mut self, index: &(usize, usize)) -> &mut C {
+        &mut self[*index]
     }
 }
 

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -25,6 +25,25 @@ fn sm() {
 }
 
 #[test]
+fn index_as_ref() {
+    let mut m = Matrix::new(2, 2, 0usize);
+    m[&(0, 0)] = 0;
+    m[&(0, 1)] = 1;
+    m[&(1, 0)] = 10;
+    m[&(1, 1)] = 11;
+    m[&(0, 1)] = 2;
+    assert_eq!(m[&(0, 0)], 0);
+    assert_eq!(m[&(0, 1)], 2);
+    assert_eq!(m[&(1, 0)], 10);
+    assert_eq!(m[&(1, 1)], 11);
+    m.fill(33);
+    assert_eq!(m[&(0, 0)], 33);
+    assert_eq!(m[&(0, 1)], 33);
+    assert_eq!(m[&(1, 0)], 33);
+    assert_eq!(m[&(1, 1)], 33);
+}
+
+#[test]
 fn from_fn() {
     let m = Matrix::from_fn(2, 3, |(row, column)| 10 * row + column);
     assert_eq!(m.rows, 2);


### PR DESCRIPTION
This comes in addition to `(usize, usize)`.