### PR TITLE
fix(perf): back out commit 808b951c5a9eb5dd25adbd46a5887525d0a0913d

### DIFF
--- a/src/directed/dijkstra.rs
+++ b/src/directed/dijkstra.rs
@@ -214,10 +214,16 @@ where
     let mut target_reached = None;
     while let Some(SmallestHolder { cost, index }) = to_see.pop() {
         let successors = {
-            let (node, _) = parents.get_index(index).unwrap();
+            let (node, &(_, c)) = parents.get_index(index).unwrap();
             if stop(node) {
                 target_reached = Some(index);
                 break;
+            }
+            // We may have inserted a node several time into the binary heap if we found
+            // a better way to access it. Ensure that we are currently dealing with the
+            // best path and discard the others.
+            if cost > c {
+                continue;
             }
             successors(node)
         };


### PR DESCRIPTION
This backs out comit 808b951c5a9eb5dd25adbd46a5887525d0a0913d "Remove optimization which gives worst benchmark results", as it severely degrades performances as shown in
<https://github.com/evenfurther/pathfinding/issues/639>.