### PR TITLE
fix(dijkstra)!: remove unneeded partial cost parameter

### DIFF
--- a/src/directed/dijkstra.rs
+++ b/src/directed/dijkstra.rs
@@ -348,7 +348,7 @@ impl<N, C, FN, IN> Iterator for DijkstraReachable<N, C, FN>
 where
     N: Eq + Hash + Clone,
     C: Zero + Ord + Copy + Hash,
-    FN: FnMut(&N, C) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = (N, C)>,
 {
     type Item = DijkstraReachableItem<N, C>;
@@ -367,7 +367,7 @@ where
                     parent: self.parents.get_index(*parent_index).map(|x| x.0.clone()),
                     total_cost,
                 });
-                (self.successors)(node, total_cost)
+                (self.successors)(node)
             };
             for (successor, move_cost) in successors {
                 let new_cost = cost + move_cost;
@@ -404,14 +404,13 @@ where
 /// Visit all nodes that are reachable from a start node. The node
 /// will be visited in order of cost, with the closest nodes first.
 ///
-/// The `successors` function receives the current node and the best
-/// cost up to this node, and returns an iterator of successors
-/// associated with their move cost.
+/// The `successors` function receives the current node, and returns
+/// an iterator of successors associated with their move cost.
 pub fn dijkstra_reach<N, C, FN, IN>(start: &N, successors: FN) -> DijkstraReachable<N, C, FN>
 where
     N: Eq + Hash + Clone,
     C: Zero + Ord + Copy,
-    FN: FnMut(&N, C) -> IN,
+    FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = (N, C)>,
 {
     let mut to_see = BinaryHeap::new();

--- a/tests/dijkstra-reach.rs
+++ b/tests/dijkstra-reach.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 #[test]
 fn dijkstra_reach_numbers() {
-    let reach = dijkstra_reach(&0, |prev, _| vec![(prev + 1, 1), (prev * 2, *prev)])
+    let reach = dijkstra_reach(&0, |prev| vec![(prev + 1, 1), (prev * 2, *prev)])
         .take_while(|x| x.total_cost < 100)
         .collect_vec();
     // the total cost should equal to the node's value, since the starting node is 0 and the cost to reach a successor node is equal to the increase in the node's value
@@ -30,13 +30,7 @@ fn dijkstra_reach_graph() {
     graph.insert("B", vec![("C", 2)]);
     graph.insert("C", vec![]);
 
-    let mut costs = HashMap::new();
-
-    let reach = dijkstra_reach(&"A", |prev, cost| {
-        costs.insert(*prev, cost);
-        graph[prev].clone()
-    })
-    .collect_vec();
+    let reach = dijkstra_reach(&"A", |prev| graph[prev].clone()).collect_vec();
 
     // need to make sure that a node won't be returned twice when a better path is found after the first candidate
     assert!(
@@ -59,8 +53,4 @@ fn dijkstra_reach_graph() {
                 },
             ]
     );
-
-    for item in reach {
-        assert!(item.total_cost == costs[item.node]);
-    }
 }


### PR DESCRIPTION
The `dijkstra_reach` function used a successors function which not only took the node whose successors are seeked, but also the cost so far to reach this node. This is an oversight, as this information can be retrieved from the iterator returned by `dijkstra_reach`.

The user is free to stop iterating if a maximum cost is reached, so there is no loss in functionality.

Fix #647