### PR TITLE
Update MSRV to 1.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Samuel Tardieu <sam@rfc1149.net>"]
 categories = ["algorithms"]
 readme = "README.md"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.86.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/src/directed/astar.rs
+++ b/src/directed/astar.rs
@@ -364,9 +364,7 @@ impl<N: Clone + Eq + Hash> AstarSolution<N> {
     }
 
     fn next_vec(&mut self) {
-        while self.current.last().map(Vec::len) == Some(1) {
-            self.current.pop();
-        }
+        while self.current.pop_if(|v| v.len() == 1).is_some() {}
         self.current.last_mut().map(Vec::pop);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //! in this context, you can wrap them into compliant types using the
 //! [ordered-float](https://crates.io/crates/ordered-float) crate.
 //!
-//! The minimum supported Rust version (MSRV) is Rust 1.85.0.
+//! The minimum supported Rust version (MSRV) is Rust 1.86.0.
 //!
 //! [A*]: https://en.wikipedia.org/wiki/A*_search_algorithm
 //! [BFS]: https://en.wikipedia.org/wiki/Breadth-first_search


### PR DESCRIPTION
Note: the PR will fail until 1.86 is released

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect the new minimum supported Rust version (1.86.0).

- **Refactor**
  - Improved internal logic for vector handling in the A* algorithm, with no changes to public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->