### PR TITLE
fix(CI): use nightly for checking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/checkout@v4
       - run: sh tests/check-msrv-consistency.sh
       - run: |
-          rustup install --profile minimal stable
-          rustup default stable
+          rustup install --profile minimal nightly
+          rustup default nightly
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-targets
 


### PR DESCRIPTION
In order to test with not yet released Rust versions, the `check` step, which is run first, needs to use the most recent compiler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated our internal build and testing processes to utilize a more advanced version of our core toolset. This update enhances our automated workflows and ensures our quality assurance practices remain aligned with the latest improvements. There are no visible changes to the application's public features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->