### PR TITLE
Fix missing link in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! - [connected components](undirected/connected_components/index.html): find disjoint connected sets of vertices ([⇒ Wikipedia][Connected components])
 //! - [Kruskal](undirected/kruskal/index.html): find a minimum-spanning-tree ([⇒ Wikipedia][Kruskal])
 //! - [Prim](undirected/prim/index.html): find a minimum-spanning-tree ([⇒ Wikipedia][Prim])
-//! - [cliques]: find maximum cliques in a graph ([= Wikipedia][BronKerbosch])
+//! - [cliques](undirected/cliques/index.html): find maximum cliques in a graph ([= Wikipedia][BronKerbosch])
 //!
 //! ### Matching
 //!


### PR DESCRIPTION
Hello,

It seems that there is a missing link in the documentation.

Best

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the algorithm reference documentation by adding a direct link, making it easier to access detailed guidance and enhancing overall clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->