### PR TITLE
fix(style): do not use `core::iter::once()` for chaining

### DIFF
--- a/src/undirected/connected_components.rs
+++ b/src/undirected/connected_components.rs
@@ -3,7 +3,6 @@
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
-use std::iter::once;
 use std::marker::PhantomData;
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -136,7 +135,7 @@ where
                 .map(|s| {
                     neighbours(s)
                         .into_iter()
-                        .chain(once(s.clone()))
+                        .chain([s.clone()])
                         .collect::<Vec<_>>()
                 })
                 .collect::<Vec<_>>(),


### PR DESCRIPTION
A single element array also implements `IntoIterator`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->