### PR TITLE
chore: make some functions const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -68,6 +68,7 @@ yanked = "warn"
 # output a note when they are encountered.
 ignore = [
   "RUSTSEC-2025-0141",  # bincode is no longer maintained, and is used by iai-callgrind
+  "RUSTSEC-2026-0173",  # proc-macro-error2 is no longer maintained, and is used by iai-callgrind
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/examples/sliding-puzzle.rs
+++ b/examples/sliding-puzzle.rs
@@ -158,7 +158,7 @@ fn main() {
             || {
                 let result = idastar(&b, Game::successors, |b| b.weight, Game::solved).unwrap();
                 println!("idastar: {} moves in {:.3?}", result.1, start.elapsed());
-                assert!(result.0.last().unwrap().weight == 0);
+                assert_eq!(result.0.last().unwrap().weight, 0);
                 result.1
             }
         });
@@ -166,7 +166,7 @@ fn main() {
             {
                 let result = astar(&b, Game::successors, |b| b.weight, Game::solved).unwrap();
                 println!("astar: {} moves in {:.3?}", result.1, start.elapsed());
-                assert!(result.0.last().unwrap().weight == 0);
+                assert_eq!(result.0.last().unwrap().weight, 0);
                 result.1
             },
             idastar_handle.join().unwrap(),

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -578,9 +578,8 @@ impl Iterator for GridIntoIterator {
                     return r;
                 }
             }
-        } else {
-            self.grid.exclusions.pop()
         }
+        self.grid.exclusions.pop()
     }
 }
 
@@ -625,15 +624,14 @@ impl Iterator for GridIterator<'_> {
                     return r;
                 }
             }
-        } else {
-            self.grid
-                .exclusions
-                .get_index(self.x)
-                .inspect(|_| {
-                    self.x += 1;
-                })
-                .copied()
         }
+        self.grid
+            .exclusions
+            .get_index(self.x)
+            .inspect(|_| {
+                self.x += 1;
+            })
+            .copied()
     }
 }
 

--- a/src/undirected/connected_components.rs
+++ b/src/undirected/connected_components.rs
@@ -163,7 +163,7 @@ where
     }
 }
 
-fn find(table: &mut [usize], mut x: usize) -> usize {
+const fn find(table: &mut [usize], mut x: usize) -> usize {
     while table[x] != x {
         let t = table[x];
         table[x] = table[table[x]];

--- a/src/undirected/kruskal.rs
+++ b/src/undirected/kruskal.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use std::mem;
 
 // Find parent and compress path by path halving.
-fn find(parents: &mut [usize], mut node: usize) -> usize {
+const fn find(parents: &mut [usize], mut node: usize) -> usize {
     while parents[node] != node {
         parents[node] = parents[parents[node]];
         node = parents[node];
@@ -14,7 +14,7 @@ fn find(parents: &mut [usize], mut node: usize) -> usize {
     node
 }
 
-fn union(parents: &mut [usize], ranks: &mut [usize], mut a: usize, mut b: usize) {
+const fn union(parents: &mut [usize], ranks: &mut [usize], mut a: usize, mut b: usize) {
     if ranks[a] < ranks[b] {
         mem::swap(&mut a, &mut b);
     }

--- a/tests/connected-components.rs
+++ b/tests/connected-components.rs
@@ -10,11 +10,11 @@ fn basic_separate_components() {
     let (h, g) = separate_components(&groups);
     assert!([1, 2, 3, 4].iter().map(|n| h[n]).all_equal());
     assert_eq!(h[&5], h[&6]);
-    assert!(h[&1] != h[&5]);
+    assert_ne!(h[&1], h[&5]);
     assert_eq!(h.len(), 6);
     assert_eq!(g[0], g[1]);
     assert_eq!(g[0], g[3]);
-    assert!(g[0] != g[2]);
+    assert_ne!(g[0], g[2]);
     assert_eq!(g.len(), 4);
 }
 
@@ -26,7 +26,7 @@ fn empty_separate_components() {
     assert_eq!(h.len(), 4);
     assert_eq!(g[0], g[1]);
     assert_eq!(g[0], g[3]);
-    assert!(g[0] != g[2]);
+    assert_ne!(g[0], g[2]);
     assert_eq!(g[2], usize::MAX);
     assert_eq!(g.len(), 4);
 }

--- a/tests/dijkstra-reach.rs
+++ b/tests/dijkstra-reach.rs
@@ -35,24 +35,24 @@ fn dijkstra_reach_graph() {
     let reach = dijkstra_reach(&"A", |prev| graph[prev].clone()).collect_vec();
 
     // need to make sure that a node won't be returned twice when a better path is found after the first candidate
-    assert!(
-        reach
-            == vec![
-                DijkstraReachableItem {
-                    node: "A",
-                    parent: None,
-                    total_cost: 0,
-                },
-                DijkstraReachableItem {
-                    node: "B",
-                    parent: Some("A"),
-                    total_cost: 2,
-                },
-                DijkstraReachableItem {
-                    node: "C",
-                    parent: Some("B"),
-                    total_cost: 4,
-                },
-            ]
+    assert_eq!(
+        reach,
+        vec![
+            DijkstraReachableItem {
+                node: "A",
+                parent: None,
+                total_cost: 0,
+            },
+            DijkstraReachableItem {
+                node: "B",
+                parent: Some("A"),
+                total_cost: 2,
+            },
+            DijkstraReachableItem {
+                node: "C",
+                parent: Some("B"),
+                total_cost: 4,
+            },
+        ]
     );
 }

--- a/tests/graph_guide_examples.rs
+++ b/tests/graph_guide_examples.rs
@@ -365,7 +365,7 @@ fn test_spatial_graph_example() {
     // Verify a path was found - the exact path may vary based on the algorithm
     // Just ensure we got a valid result
     assert!(!path.is_empty());
-    assert!(path[0] == 1);
-    assert!(path[path.len() - 1] == 3);
+    assert_eq!(path[0], 1);
+    assert_eq!(path[path.len() - 1], 3);
     assert!(cost > 0);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal connected-components and minimum spanning tree helpers to be compile-time evaluable while preserving existing union-find behavior.
  * Simplified iteration logic in grid iterators without changing traversal results.
* **Bug Fixes**
  * Strengthened example and test validations to use explicit equality assertions (e.g., final heuristic weight and expected reach/path endpoints).
* **Chores**
  * Updated the security advisory ignore list to exclude an additional related advisory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->