### PR TITLE
perf: reduce hashing and allocations in search algorithms

### DIFF
--- a/src/directed/bfs.rs
+++ b/src/directed/bfs.rs
@@ -190,62 +190,69 @@ where
     let start = start.into();
     let end = end.into();
 
-    let mut predecessors: FxIndexMap<N, Option<usize>> = FxIndexMap::default();
-    predecessors.extend(start.into_iter().cloned().map(|n| (n, None)));
-    let mut successors: FxIndexMap<N, Option<usize>> = FxIndexMap::default();
-    successors.extend(end.into_iter().cloned().map(|n| (n, None)));
+    for start_node in &start {
+        if end.contains(start_node) {
+            return Some(vec![start_node.clone()]);
+        }
+    }
+
+    let mut predecessors: FxIndexMap<N, usize> = FxIndexMap::default();
+    predecessors.extend(start.into_iter().cloned().map(|n| (n, usize::MAX)));
+    let mut successors: FxIndexMap<N, usize> = FxIndexMap::default();
+    successors.extend(end.into_iter().cloned().map(|n| (n, usize::MAX)));
 
     let mut i_forwards = 0;
     let mut i_backwards = 0;
     let middle = 'l: loop {
-        for _ in 0..(predecessors.len() - i_forwards) {
-            let node = predecessors.get_index(i_forwards).unwrap().0;
-            for successor_node in successors_fn(node) {
-                if !predecessors.contains_key(&successor_node) {
-                    predecessors.insert(successor_node.clone(), Some(i_forwards));
-                }
-                if successors.contains_key(&successor_node) {
-                    break 'l Some(successor_node);
-                }
-            }
-            i_forwards += 1;
-        }
-
-        for _ in 0..(successors.len() - i_backwards) {
-            let node = successors.get_index(i_backwards).unwrap().0;
-            for predecessor_node in predecessors_fn(node) {
-                if !successors.contains_key(&predecessor_node) {
-                    successors.insert(predecessor_node.clone(), Some(i_backwards));
-                }
-                if predecessors.contains_key(&predecessor_node) {
-                    break 'l Some(predecessor_node);
-                }
-            }
-            i_backwards += 1;
-        }
-
-        if i_forwards == predecessors.len() && i_backwards == successors.len() {
+        let forward_layer = predecessors.len() - i_forwards;
+        let backward_layer = successors.len() - i_backwards;
+        if forward_layer == 0 && backward_layer == 0 {
             break 'l None;
+        }
+
+        // Always expand the smaller frontier so the searches meet sooner.
+        if backward_layer == 0 || (forward_layer > 0 && forward_layer <= backward_layer) {
+            let layer_end = predecessors.len();
+            while i_forwards < layer_end {
+                let node = predecessors.get_index(i_forwards).unwrap().0;
+                for successor_node in successors_fn(node) {
+                    if let Vacant(e) = predecessors.entry(successor_node) {
+                        if successors.contains_key(e.key()) {
+                            let mid = e.key().clone();
+                            e.insert(i_forwards);
+                            break 'l Some(mid);
+                        }
+                        e.insert(i_forwards);
+                    }
+                }
+                i_forwards += 1;
+            }
+        } else {
+            let layer_end = successors.len();
+            while i_backwards < layer_end {
+                let node = successors.get_index(i_backwards).unwrap().0;
+                for predecessor_node in predecessors_fn(node) {
+                    if let Vacant(e) = successors.entry(predecessor_node) {
+                        if predecessors.contains_key(e.key()) {
+                            let mid = e.key().clone();
+                            e.insert(i_backwards);
+                            break 'l Some(mid);
+                        }
+                        e.insert(i_backwards);
+                    }
+                }
+                i_backwards += 1;
+            }
         }
     };
 
     middle.map(|middle| {
-        // Path found!
-        // Build the path.
-        let mut path = vec![];
-        // From middle to the start.
-        let mut node = Some(middle.clone());
-        while let Some(n) = node {
-            path.push(n.clone());
-            node = predecessors[&n].map(|i| predecessors.get_index(i).unwrap().0.clone());
-        }
-        // Reverse, to put start at the front.
-        path.reverse();
-        // And from middle to the end.
-        let mut node = successors[&middle].map(|i| successors.get_index(i).unwrap().0.clone());
-        while let Some(n) = node {
-            path.push(n.clone());
-            node = successors[&n].map(|i| successors.get_index(i).unwrap().0.clone());
+        let mid_idx = predecessors.get_index_of(&middle).unwrap();
+        let mut path = reverse_path(&predecessors, |&p| p, mid_idx);
+        let mut i = successors[&middle];
+        while let Some((node, &parent)) = successors.get_index(i) {
+            path.push(node.clone());
+            i = parent;
         }
         path
     })

--- a/src/directed/dfs.rs
+++ b/src/directed/dfs.rs
@@ -1,11 +1,13 @@
 //! Compute a path using the [depth-first search
 //! algorithm](https://en.wikipedia.org/wiki/Depth-first_search).
 
-use std::collections::HashSet;
+use indexmap::map::Entry::{Occupied, Vacant};
 use std::hash::Hash;
 use std::iter::FusedIterator;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use super::reverse_path;
+use crate::FxIndexMap;
+use rustc_hash::FxHashSet;
 
 /// Compute a path using the [depth-first search
 /// algorithm](https://en.wikipedia.org/wiki/Depth-first_search).
@@ -46,6 +48,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 /// assert_eq!(dfs(1, |&n| vec![n*n, n+1].into_iter().filter(|&x| x <= 17), |&n| n == 17),
 ///            Some(vec![1, 2, 4, 16, 17]));
 /// ```
+#[expect(clippy::missing_panics_doc)]
 pub fn dfs<N, FN, IN, FS>(start: N, mut successors: FN, mut success: FS) -> Option<Vec<N>>
 where
     N: Clone + Eq + Hash,
@@ -53,40 +56,41 @@ where
     IN: IntoIterator<Item = N>,
     FS: FnMut(&N) -> bool,
 {
-    let mut to_visit = vec![start];
-    let mut visited = FxHashSet::default();
-    let mut parents = FxHashMap::default();
-    while let Some(node) = to_visit.pop() {
-        if visited.insert(node.clone()) {
-            if success(&node) {
-                return Some(build_path(node, &parents));
+    let mut parents: FxIndexMap<N, usize> = FxIndexMap::default();
+    parents.insert(start, usize::MAX);
+    let mut stack = vec![0];
+    let mut expanded = vec![false];
+    while let Some(index) = stack.pop() {
+        if expanded[index] {
+            continue;
+        }
+        expanded[index] = true;
+        let neighbs = {
+            let (node, _) = parents.get_index(index).unwrap();
+            if success(node) {
+                return Some(reverse_path(&parents, |&p| p, index));
             }
-            for next in successors(&node)
-                .into_iter()
-                .collect::<Vec<_>>()
-                .into_iter()
-                .rev()
-            {
-                if !visited.contains(&next) {
-                    parents.insert(next.clone(), node.clone());
-                    to_visit.push(next);
+            successors(node).into_iter().collect::<Vec<_>>()
+        };
+        for next in neighbs.into_iter().rev() {
+            match parents.entry(next) {
+                Vacant(e) => {
+                    let n = e.index();
+                    e.insert(index);
+                    expanded.push(false);
+                    stack.push(n);
+                }
+                Occupied(mut e) => {
+                    let n = e.index();
+                    if !expanded[n] {
+                        e.insert(index);
+                        stack.push(n);
+                    }
                 }
             }
         }
     }
     None
-}
-
-fn build_path<N>(mut node: N, parents: &FxHashMap<N, N>) -> Vec<N>
-where
-    N: Clone + Eq + Hash,
-{
-    let mut path = vec![node.clone()];
-    while let Some(parent) = parents.get(&node).cloned() {
-        path.push(parent.clone());
-        node = parent;
-    }
-    path.into_iter().rev().collect()
 }
 
 /// Visit all nodes that are reachable from a start node. The node will be visited
@@ -130,7 +134,7 @@ where
 {
     DfsReachable {
         to_see: vec![start],
-        visited: HashSet::new(),
+        visited: FxHashSet::default(),
         successors,
     }
 }
@@ -138,7 +142,7 @@ where
 /// Struct returned by [`dfs_reach`].
 pub struct DfsReachable<N, FN> {
     to_see: Vec<N>,
-    visited: HashSet<N>,
+    visited: FxHashSet<N>,
     successors: FN,
 }
 
@@ -150,7 +154,7 @@ where
     /// nodes. Not all nodes are necessarily known in advance, and
     /// new reachable nodes may be discovered while using the iterator.
     pub fn remaining_nodes_low_bound(&self) -> usize {
-        self.to_see.iter().collect::<HashSet<_>>().len()
+        self.to_see.iter().collect::<FxHashSet<_>>().len()
     }
 }
 
@@ -165,10 +169,9 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let n = self.to_see.pop()?;
-            if self.visited.contains(&n) {
+            if !self.visited.insert(n.clone()) {
                 continue;
             }
-            self.visited.insert(n.clone());
             let mut to_insert = Vec::new();
             for s in (self.successors)(&n) {
                 if !self.visited.contains(&s) {

--- a/src/directed/dijkstra.rs
+++ b/src/directed/dijkstra.rs
@@ -5,7 +5,7 @@ use super::reverse_path;
 use crate::FxIndexMap;
 use indexmap::map::Entry::{Occupied, Vacant};
 use num_traits::Zero;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 use std::hash::Hash;
@@ -328,7 +328,6 @@ pub struct DijkstraReachable<N, C, FN> {
     to_see: BinaryHeap<SmallestHolder<C>>,
     seen: FxHashSet<usize>,
     parents: FxIndexMap<N, (usize, C)>,
-    total_costs: FxHashMap<N, C>,
     successors: FN,
 }
 
@@ -347,7 +346,7 @@ pub struct DijkstraReachableItem<N, C> {
 impl<N, C, FN, IN> Iterator for DijkstraReachable<N, C, FN>
 where
     N: Eq + Hash + Clone,
-    C: Zero + Ord + Copy + Hash,
+    C: Zero + Ord + Copy,
     FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = (N, C)>,
 {
@@ -360,11 +359,10 @@ where
             }
             let item;
             let successors = {
-                let (node, (parent_index, _)) = self.parents.get_index(index).unwrap();
-                let total_cost = self.total_costs[node];
+                let (node, &(parent_index, total_cost)) = self.parents.get_index(index).unwrap();
                 item = Some(DijkstraReachableItem {
                     node: node.clone(),
-                    parent: self.parents.get_index(*parent_index).map(|x| x.0.clone()),
+                    parent: self.parents.get_index(parent_index).map(|x| x.0.clone()),
                     total_cost,
                 });
                 (self.successors)(node)
@@ -372,17 +370,15 @@ where
             for (successor, move_cost) in successors {
                 let new_cost = cost + move_cost;
                 let n;
-                match self.parents.entry(successor.clone()) {
+                match self.parents.entry(successor) {
                     Vacant(e) => {
                         n = e.index();
                         e.insert((index, new_cost));
-                        self.total_costs.insert(successor, new_cost);
                     }
                     Occupied(mut e) => {
                         if e.get().1 > new_cost {
                             n = e.index();
                             e.insert((index, new_cost));
-                            self.total_costs.insert(successor, new_cost);
                         } else {
                             continue;
                         }
@@ -422,16 +418,12 @@ where
     let mut parents: FxIndexMap<N, (usize, C)> = FxIndexMap::default();
     parents.insert(start.clone(), (usize::MAX, Zero::zero()));
 
-    let mut total_costs = FxHashMap::default();
-    total_costs.insert(start.clone(), Zero::zero());
-
     let seen = FxHashSet::default();
 
     DijkstraReachable {
         to_see,
         seen,
         parents,
-        total_costs,
         successors,
     }
 }

--- a/src/directed/idastar.rs
+++ b/src/directed/idastar.rs
@@ -1,7 +1,7 @@
 //! Compute a shortest path using the [IDA* search
 //! algorithm](https://en.wikipedia.org/wiki/Iterative_deepening_A*).
 
-use indexmap::IndexSet;
+use crate::FxIndexSet;
 use num_traits::Zero;
 use std::{hash::Hash, ops::ControlFlow};
 
@@ -85,7 +85,8 @@ where
     FH: FnMut(&N) -> C,
     FS: FnMut(&N) -> bool,
 {
-    let mut path = IndexSet::from([start.clone()]);
+    let mut path = FxIndexSet::default();
+    path.insert(start.clone());
 
     std::iter::repeat(())
         .try_fold(heuristic(start), |bound, ()| {
@@ -106,7 +107,7 @@ where
 }
 
 fn search<N, C, FN, IN, FH, FS>(
-    path: &mut IndexSet<N>,
+    path: &mut FxIndexSet<N>,
     cost: C,
     bound: C,
     successors: &mut FN,

--- a/src/directed/mod.rs
+++ b/src/directed/mod.rs
@@ -22,15 +22,12 @@ where
     N: Eq + Hash + Clone,
     F: FnMut(&V) -> usize,
 {
+    let mut path = Vec::new();
     let mut i = start;
-    let path = std::iter::from_fn(|| {
-        parents.get_index(i).map(|(node, value)| {
-            i = parent(value);
-            node
-        })
-    })
-    .collect::<Vec<&N>>();
-    // Collecting the going through the vector is needed to revert the path because the
-    // unfold iterator is not double-ended due to its iterative nature.
-    path.into_iter().rev().cloned().collect()
+    while let Some((node, value)) = parents.get_index(i) {
+        path.push(node.clone());
+        i = parent(value);
+    }
+    path.reverse();
+    path
 }

--- a/src/directed/yen.rs
+++ b/src/directed/yen.rs
@@ -1,10 +1,10 @@
 //! Compute k-shortest paths using [Yen's search
 //! algorithm](https://en.wikipedia.org/wiki/Yen%27s_algorithm).
 use num_traits::Zero;
+use rustc_hash::FxHashSet;
 use std::cmp::Ordering;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
-use std::collections::HashSet;
 use std::hash::Hash;
 
 use super::dijkstra::dijkstra_internal;
@@ -115,7 +115,7 @@ where
         return vec![];
     };
 
-    let mut visited = HashSet::new();
+    let mut visited = FxHashSet::default();
     // A vector containing our paths.
     let mut routes = vec![Path { nodes: n, cost: c }];
     // A min-heap to store our lowest-cost route candidate
@@ -132,7 +132,7 @@ where
             let spur_node = &previous[i];
             let root_path = &previous[0..i];
 
-            let mut filtered_edges = HashSet::new();
+            let mut filtered_edges = FxHashSet::default();
             for path in &routes {
                 if path.nodes.len() > i + 1
                     && &path.nodes[0..i] == root_path
@@ -141,7 +141,7 @@ where
                     filtered_edges.insert((&path.nodes[i], &path.nodes[i + 1]));
                 }
             }
-            let filtered_nodes: HashSet<&N> = HashSet::from_iter(root_path);
+            let filtered_nodes: FxHashSet<&N> = FxHashSet::from_iter(root_path);
             // We are creating a new successor function that will not return the
             // filtered edges and nodes that routes already used.
             let mut filtered_successor = |n: &N| {

--- a/tests/pathfinding.rs
+++ b/tests/pathfinding.rs
@@ -347,6 +347,17 @@ mod ex2 {
     }
 
     #[test]
+    fn bfs_bidirectional_same_start_and_end() {
+        #[expect(clippy::type_complexity)]
+        static SUCCESSORS: fn(&(usize, usize)) -> Vec<(usize, usize)> =
+            |n| successors(n).into_iter().map(|(n, _)| n).collect();
+
+        let path =
+            bfs_bidirectional(&(2, 3), &(2, 3), SUCCESSORS, SUCCESSORS).expect("path not found");
+        assert_eq!(path, vec![(2, 3)]);
+    }
+
+    #[test]
     fn dfs_path_ok() {
         const GOAL: (usize, usize) = (6, 3);
         let path = dfs(


### PR DESCRIPTION
## Summary

These changes target the obvious costs on the search hot paths, not the algorithms themselves.

- **IDA\*** kept the current path in an `IndexSet` with SipHash. Every recursive step hashed against that set. It now uses the crate's `FxIndexSet`.
- **DFS** cloned every node into a parent `HashMap` and walked that map to rebuild the path. It now stores parent indices in an `FxIndexMap` and uses the shared `reverse_path` helper, same as BFS/Dijkstra.
- **Bidirectional BFS** always expanded a full layer on each side and did not treat overlapping start/end as a path. It now returns immediately when start and end share a node, expands the smaller frontier, and rebuilds the meeting path with fewer clones.
- **`dijkstra_reach`** kept a second `total_costs` map beside the parent map. Cost already lives in the parent entry, so the extra map (and the `C: Hash` bound it forced) is gone.
- **`reverse_path`** collected references, then cloned them in reverse. It now clones once into a `Vec` and reverses in place.
- **Yen** and **`dfs_reach`** used std `HashSet` (SipHash). They now use `FxHashSet`.

## Benchmarks

Compared against `main` on the same machine (Criterion, `--release`). Open-grid corner-to-corner.

**Machine:** Apple M2 (8-core, 16 GB), macOS 26.5.2, arm64, rustc 1.97.1.

| | 65×65 (`algos`) | 129×129 | 257×257 | 513×513 |
|---|---|---|---|---|
| **IDA\*** | −36% (17.5 → 11.4 µs) | −38% (37 → 23 µs) | −39% (70 → 42 µs) | −40% (145 → 87 µs) |
| **DFS** | −12% | −31% (1.33 → 0.90 ms) | −20% (4.74 → 3.85 ms) | −10% (23.4 → 21.1 ms) |
| **Bidirectional BFS** | noise | −19% (1.02 → 0.84 ms) | −21% (4.29 → 3.46 ms) | −31% (23.7 → 16.3 ms) |

On larger open grids (1024²–3072²) DFS stays 40–70% faster and bidirectional BFS is typically 13–20% faster. A\* and unidirectional BFS are unchanged — they were not the target.

The 65×65 suite hides the bidirectional-BFS gain; it shows up once the two search waves are large enough that expanding the smaller frontier matters.

## Behavioral notes

- `bfs_bidirectional(start, start)` now returns `[start]`. It previously returned `None`.
- `dijkstra_reach` no longer requires `C: Hash`. Existing callers are unaffected.

## Test plan

- [ ] `cargo test`
- [ ] `bfs_bidirectional` same start and end (new test)
- [ ] DFS still returns a valid simple path on the existing maze cases
- [ ] `cargo bench --bench algos` vs `main` if you want to reproduce the 65×65 numbers