### PR TITLE
fix(prim): use edges that name the starting node second

### DIFF
--- a/src/undirected/prim.rs
+++ b/src/undirected/prim.rs
@@ -16,9 +16,20 @@ where
         return vec![];
     };
 
+    // Edges are undirected, so an edge touching the starting node may name it either first
+    // or second. Both forms have to be offered here: once the loop below has marked the
+    // starting node as visited, neither of its checks can reach back to it.
     let mut priority_queue = edges
         .iter()
-        .filter_map(|(n, n1, c)| (n == start).then_some(Reverse((c, n, n1))))
+        .filter_map(|(n, n1, c)| {
+            if n == start {
+                Some(Reverse((c, n, n1)))
+            } else if n1 == start {
+                Some(Reverse((c, n1, n)))
+            } else {
+                None
+            }
+        })
         .collect::<BinaryHeap<_>>();
 
     let (mut mst, mut visited) = (Vec::new(), HashSet::new());

--- a/tests/prim.rs
+++ b/tests/prim.rs
@@ -81,3 +81,12 @@ fn another_test() {
         ]
     );
 }
+
+#[test]
+// An edge incident to the starting node was ignored unless the starting node happened to be
+// written as its first endpoint, which could leave the cheapest way into the tree unusable.
+fn start_node_reached_from_either_side() {
+    let edges = vec![(1, 0, 10), (2, 1, 1), (2, 0, 1)];
+    let weight: i32 = prim(&edges).iter().map(|&(_, _, c)| c).sum();
+    assert_eq!(weight, 2);
+}


### PR DESCRIPTION
Closes #794.

`prim` seeded its queue only with edges whose first endpoint was the starting node. Edges are undirected, so an edge touching the starting node may be written either way round, and the main loop cannot recover the reversed ones: both of its checks require the far endpoint to be unvisited, and the starting node is visited from the outset.

This offers both orientations when seeding.

### Checking

Verified against `kruskal` over 200 random connected graphs whose edges are written in either direction, comparing total weight.

The three existing tests pin down the exact output including tie-breaking and are unchanged: all of them happen to write the starting node first, which is why they never caught this. A regression test covers the reversed case.
