### PR TITLE
fix(yen): charge a spur path for one parallel edge, not all of them

### DIFF
--- a/src/directed/yen.rs
+++ b/src/directed/yen.rs
@@ -202,17 +202,21 @@ where
 fn make_cost<N, FN, IN, C>(nodes: &[N], successors: &mut FN) -> C
 where
     N: Eq,
-    C: Zero,
+    C: Zero + Ord + Copy,
     FN: FnMut(&N) -> IN,
     IN: IntoIterator<Item = (N, C)>,
 {
     let mut cost = C::zero();
     for edge in nodes.windows(2) {
-        for (n, c) in successors(&edge[0]) {
-            if n == edge[1] {
-                cost = cost + c;
-            }
-        }
+        // Several edges may join the same two nodes; a shortest path takes the cheapest of
+        // them, so charging the path for all of them would overstate its cost.
+        let step = successors(&edge[0])
+            .into_iter()
+            .filter(|(n, _)| *n == edge[1])
+            .map(|(_, c)| c)
+            .min()
+            .unwrap_or_else(C::zero);
+        cost = cost + step;
     }
     cost
 }

--- a/tests/yen.rs
+++ b/tests/yen.rs
@@ -193,3 +193,22 @@ fn k_zero() {
     );
     assert_eq!(result, Vec::new());
 }
+
+#[test]
+// The cost of a spur candidate was recomputed by adding up *every* edge between two
+// consecutive nodes, so parallel edges were all charged instead of just the one taken.
+fn parallel_edges_are_not_charged_twice() {
+    let successors = |&n: &char| -> Vec<(char, u32)> {
+        match n {
+            '0' => vec![('a', 1), ('b', 1)],
+            'a' => vec![('c', 1)],
+            'b' => vec![('c', 5)],
+            'c' => vec![('d', 1), ('d', 9)],
+            _ => vec![],
+        }
+    };
+    assert_eq!(
+        yen(&'0', successors, |&n| n == 'd', 2),
+        vec![(vec!['0', 'a', 'c', 'd'], 3), (vec!['0', 'b', 'c', 'd'], 7)]
+    );
+}


### PR DESCRIPTION
Closes #796.

Every candidate after the first had its cost recomputed by `make_cost`, which added up every edge joining each pair of consecutive nodes rather than the one the path takes. On a graph with parallel edges the reported cost was too high, and since that value orders the candidate against the others it also affected which paths came back and in what order.

This takes the cheapest edge between two consecutive nodes, which is the one a shortest path uses.

Simple graphs are unaffected: there is only ever one edge to choose from, so the sum and the minimum are the same number.

### Checking

Verified against a brute-force enumeration of every loopless path over 150 random multigraphs, comparing the k cheapest costs. A regression test covers the reported case directly.
