### PR TITLE
fix(tests): stop CRLF translation from corrupting the codejam fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# These fixtures are parsed byte for byte by tests/codejam-2017-a.rs, and the expected
+# output is compared verbatim, so their line endings must survive checkout untouched.
+tests/A-small-practice.in -text
+tests/A-small-practice.out -text


### PR DESCRIPTION
Closes #805.

Marks `tests/A-small-practice.in` and `tests/A-small-practice.out` as binary, so their bytes survive checkout whatever the contributor's `core.autocrlf` setting is.

Only those two files are affected; everything else keeps its current behaviour. No source or test code changes.
