### PR TITLE
refactor(edmonds-karp): drop two unsafe Send impls the compiler already provides

### DIFF
--- a/src/directed/edmonds_karp.rs
+++ b/src/directed/edmonds_karp.rs
@@ -352,8 +352,6 @@ pub struct SparseCapacity<C> {
     residuals: BTreeMap<usize, BTreeMap<usize, C>>,
 }
 
-unsafe impl<C: Send> Send for SparseCapacity<C> {}
-
 impl<C: Copy + Eq + Zero + Signed + Bounded + Ord> SparseCapacity<C> {
     fn set_value(data: &mut BTreeMap<usize, BTreeMap<usize, C>>, from: usize, to: usize, value: C) {
         let to_remove = {
@@ -478,8 +476,6 @@ pub struct DenseCapacity<C> {
     residuals: Matrix<C>,
     flows: Matrix<C>,
 }
-
-unsafe impl<C: Send> Send for DenseCapacity<C> {}
 
 impl<C: Copy + Zero + Signed + Ord + Bounded> EdmondsKarp<C> for DenseCapacity<C> {
     fn new(size: usize, source: usize, sink: usize) -> Self {

--- a/tests/edmondskarp.rs
+++ b/tests/edmondskarp.rs
@@ -273,3 +273,12 @@ fn set_capacity_test() {
     ek.augment();
     residual_capacities_non_negative(&ek);
 }
+
+#[test]
+fn capacities_are_send_without_an_unsafe_impl() {
+    // Every field of both types is `Send` when `C` is, so the compiler derives this on its
+    // own; the assertion is here so that a field which is not can never be added silently.
+    const fn assert_send<T: Send>() {}
+    assert_send::<DenseCapacity<i32>>();
+    assert_send::<SparseCapacity<i32>>();
+}


### PR DESCRIPTION
Closes #817.

Removes both `unsafe impl Send`. Every field of `SparseCapacity` and `DenseCapacity` is `Send` whenever `C` is, so the compiler derives the same impl with the same bound, and the crate is left with no `unsafe` in this file at all.

Adds a compile-time assertion in its place:

```rust
const fn assert_send<T: Send>() {}
assert_send::<DenseCapacity<i32>>();
assert_send::<SparseCapacity<i32>>();
```

so the property is still verified, and a future field that is not `Send` fails the build instead of being silently promised away by the hand-written impl.

### Checking

Purely a removal; no behaviour changes. 291 tests pass, clippy and rustfmt clean.

This touches the same file as #819 but not the same lines; I checked they merge in either order.
