### PR TITLE
perf: stop copying containers that are only walked

### DIFF
--- a/src/kuhn_munkres.rs
+++ b/src/kuhn_munkres.rs
@@ -3,7 +3,7 @@
 //! [Kuhn-Munkres algorithm](https://en.wikipedia.org/wiki/Hungarian_algorithm)
 //! (also known as Hungarian algorithm).
 
-use crate::{FxIndexSet, matrix::Matrix};
+use crate::matrix::Matrix;
 use num_traits::{Bounded, Signed, Zero};
 use std::iter::Sum;
 
@@ -138,7 +138,9 @@ where
     let mut ly: Vec<C> = vec![Zero::zero(); ny];
     // s, augmenting, and slack will be reset every time they are reused. augmenting
     // contains Some(prev) when the corresponding node belongs to the augmenting path.
-    let mut s = FxIndexSet::<usize>::default();
+    // Every x node enters the alternating path at most once per root, and the set is only ever
+    // appended to and walked, so a plain vector does the job without hashing.
+    let mut s = Vec::<usize>::new();
     let mut alternating = Vec::with_capacity(ny);
     let mut slack = vec![Zero::zero(); ny];
     let mut slackx = Vec::with_capacity(ny);
@@ -149,7 +151,7 @@ where
         // loop below. Above the loop is some code to initialize the search.
         let mut y = {
             s.clear();
-            s.insert(root);
+            s.push(root);
             // Slack for a vertex y is, initially, the margin between the
             // sum of the labels of root and y, and the weight between root and y.
             // As we add x nodes to the alternating path, we update the slack to
@@ -197,7 +199,7 @@ where
                 // This y node had a predecessor, add it to the set of x nodes
                 // in the augmenting path.
                 let x = yx[y].unwrap();
-                s.insert(x);
+                s.push(x);
                 // Update slack because of the added vertex in s might contain a
                 // greater slack than with previously inserted x nodes in the augmenting
                 // path.

--- a/src/undirected/connected_components.rs
+++ b/src/undirected/connected_components.rs
@@ -115,8 +115,8 @@ where
             .filter(|&(_, n)| n != usize::MAX)
         {
             let set = gb.entry(n).or_default();
-            for e in groups[i].clone() {
-                set.insert(e);
+            for e in &groups[i] {
+                set.insert(e.clone());
             }
         }
         gb.into_values().map(|v| v.into_iter().collect()).collect()


### PR DESCRIPTION
Closes #818.

Borrows the group in `ConnectedComponents::components` rather than cloning it whole, and uses a `Vec` in `kuhn_munkres` where an `FxIndexSet` was only being appended to and iterated.

### Checking

290 tests pass, clippy and rustfmt clean.

Measured against this branch's parent, four passes with the order of the two binaries swapped on alternate passes:

- `components`, 20 000 groups of 8: consistently faster in all four passes, between 4% and 13%, so about 10%
- `kuhn_munkres`, 250x250: the passes disagree on sign, so I am claiming nothing for it — it is a simplification, not a speed-up
- `separate_components`, untouched by this change, measures unchanged, which is the control

Happy to drop the `kuhn_munkres` half if you would rather this PR only carried the part with a number behind it.

*Measured on Windows 11, Intel Core Ultra 7 265K, 64 GB RAM.*
