### PR TITLE
perf(matrix): fill a fixed buffer instead of a vector per cell

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -681,9 +681,17 @@ impl<C> Matrix<C> {
         P: FnMut((usize, usize)) -> bool,
     {
         bfs_reach(start, |&n| {
-            self.neighbours(n, diagonals)
-                .filter(|&n| predicate(n))
-                .collect::<Vec<_>>()
+            // A cell has at most eight neighbours, so they fit in a fixed buffer and the
+            // traversal need not allocate a vector for every cell it visits.
+            let mut buffer = [(0, 0); 8];
+            let mut len = 0;
+            for neighbour in self.neighbours(n, diagonals) {
+                if predicate(neighbour) {
+                    buffer[len] = neighbour;
+                    len += 1;
+                }
+            }
+            buffer.into_iter().take(len)
         })
         .collect()
     }
@@ -709,9 +717,17 @@ impl<C> Matrix<C> {
         P: FnMut((usize, usize)) -> bool,
     {
         dfs_reach(start, |&n| {
-            self.neighbours(n, diagonals)
-                .filter(|&n| predicate(n))
-                .collect::<Vec<_>>()
+            // A cell has at most eight neighbours, so they fit in a fixed buffer and the
+            // traversal need not allocate a vector for every cell it visits.
+            let mut buffer = [(0, 0); 8];
+            let mut len = 0;
+            for neighbour in self.neighbours(n, diagonals) {
+                if predicate(neighbour) {
+                    buffer[len] = neighbour;
+                    len += 1;
+                }
+            }
+            buffer.into_iter().take(len)
         })
         .collect()
     }


### PR DESCRIPTION
Closes #826.

Collects the neighbours of a cell into a fixed `[(usize, usize); 8]` rather than a vector, in `bfs_reachable` and `dfs_reachable`.

`neighbours` itself is untouched — it already returns an iterator, so only the two traversals needed changing.

### Checking

All tests pass, clippy and rustfmt clean.

Beyond those, both traversals were compared against the previous code over 6092 traversals across 60 random matrices, covering both diagonal settings and every starting cell. Identical fingerprint over every cell returned, so this is not "faster because it visits less".

Measured against this branch's parent, four passes with the order of the two binaries swapped on alternate passes, consistent in both directions:

```
Matrix::bfs_reachable, 400x400, 12% blocked:  about 26% off
Matrix::dfs_reachable, 400x400, 12% blocked:  about 31% off
```

*Measured on Windows 11, Intel Core Ultra 7 265K, 64 GB RAM.*

Same shape as #824 but independent of it: that one touches `grid.rs`, this one `matrix.rs`.
