### PR TITLE
feat: let the caller break ties in astar and idastar

### DIFF
--- a/src/directed/astar.rs
+++ b/src/directed/astar.rs
@@ -77,6 +77,45 @@ use crate::FxIndexMap;
 ///                    |&p| p == GOAL);
 /// assert_eq!(result.expect("no path found").1, 4);
 /// ```
+/// # Tie-breaking
+///
+/// Nodes whose estimated total cost is equal are taken in order of decreasing cost from the
+/// start. That is the usual recommendation, because it drives the search towards the goal
+/// rather than spreading it evenly: on an open 120x120 grid with an exact heuristic it is the
+/// difference between expanding 238 nodes and 14399, for the same path.
+///
+/// A different preference can be expressed through `heuristic`, with no change here. Give costs
+/// enough room beneath a single step and put the tie-break in that room: it reorders the queue
+/// without altering which path is cheapest, since any real difference in cost is a whole step
+/// or more.
+///
+/// ```
+/// use pathfinding::prelude::astar;
+///
+/// const STEP: u64 = 1024; // one move, leaving 1023 units of room beneath it
+///
+/// let successors = |&(x, y): &(u64, u64)| {
+///     [(1, 0), (0, 1)]
+///         .into_iter()
+///         .map(move |(dx, dy)| ((x + dx, y + dy), STEP))
+///         .filter(|&((nx, ny), _)| nx <= 2 && ny <= 2)
+///         .collect::<Vec<_>>()
+/// };
+/// let distance = |&(x, y): &(u64, u64)| STEP * ((2 - x) + (2 - y));
+///
+/// // Every way across this grid costs the same, so the tie decides which one comes back.
+/// let (over_the_top, cost) = astar(&(0, 0), successors, distance, |&n| n == (2, 2))
+///     .expect("no path found");
+/// assert_eq!(over_the_top, vec![(0, 0), (1, 0), (2, 0), (2, 1), (2, 2)]);
+///
+/// // Preferring a smaller column costs a fraction of a step, so it can only break ties.
+/// let keep_left = |n: &(u64, u64)| distance(n) + n.0;
+/// let (down_the_side, same_cost) = astar(&(0, 0), successors, keep_left, |&n| n == (2, 2))
+///     .expect("no path found");
+/// assert_eq!(down_the_side, vec![(0, 0), (0, 1), (0, 2), (1, 2), (2, 2)]);
+/// assert_eq!(cost, same_cost);
+/// ```
+///
 #[expect(clippy::missing_panics_doc)]
 pub fn astar<N, C, FN, IN, FH, FS>(
     start: &N,

--- a/src/directed/idastar.rs
+++ b/src/directed/idastar.rs
@@ -71,6 +71,11 @@ use std::{hash::Hash, ops::ControlFlow};
 ///                    |&p| p == GOAL);
 /// assert_eq!(result.expect("no path found").1, 4);
 /// ```
+/// # Tie-breaking
+///
+/// Successors whose estimated total cost is equal are explored in the order `successors`
+/// returned them, so the choice belongs to the caller: yield the preferred one first.
+///
 pub fn idastar<N, C, FN, IN, FH, FS>(
     start: &N,
     mut successors: FN,
@@ -140,7 +145,9 @@ where
                 })
             })
             .collect::<Vec<_>>();
-        neighbs.sort_unstable_by_key(|(_, _, c1)| *c1);
+        // A stable sort, so that successors of equal estimated cost stay in the order the
+        // caller produced them: that order is the caller's way of breaking the tie.
+        neighbs.sort_by_key(|(_, _, c1)| *c1);
         neighbs
     };
     let mut min = None;

--- a/tests/tiebreak.rs
+++ b/tests/tiebreak.rs
@@ -1,0 +1,110 @@
+//! Choosing between nodes of equal estimated cost, from outside the library.
+
+use pathfinding::prelude::{astar, idastar};
+use std::cell::Cell;
+
+/// One move, leaving room beneath it for a tie-break that cannot outweigh a real step.
+const STEP: u64 = 1024;
+
+const SIDE: u64 = 12;
+
+fn grid(&(x, y): &(u64, u64)) -> Vec<((u64, u64), u64)> {
+    [(1, 0), (0, 1)]
+        .into_iter()
+        .map(move |(dx, dy)| ((x + dx, y + dy), STEP))
+        .filter(|&((nx, ny), _)| nx < SIDE && ny < SIDE)
+        .collect()
+}
+
+const fn distance(&(x, y): &(u64, u64)) -> u64 {
+    STEP * ((SIDE - 1 - x) + (SIDE - 1 - y))
+}
+
+/// Every monotone route across the grid costs the same, so which one comes back is decided
+/// entirely by the tie-break, and a term smaller than a step can only affect that.
+#[test]
+fn a_term_beneath_one_step_chooses_between_equal_paths() {
+    let goal = (SIDE - 1, SIDE - 1);
+
+    let (default_path, cost) = astar(&(0, 0), grid, distance, |&n| n == goal).expect("no path");
+    let (left_path, left_cost) =
+        astar(&(0, 0), grid, |n| distance(n) + n.0, |&n| n == goal).expect("no path");
+    let (top_path, top_cost) =
+        astar(&(0, 0), grid, |n| distance(n) + n.1, |&n| n == goal).expect("no path");
+
+    // Same length, because the tie-break never outweighs a step.
+    assert_eq!(cost, left_cost);
+    assert_eq!(cost, top_cost);
+    assert_eq!(cost, STEP * 2 * (SIDE - 1));
+
+    // Preferring a smaller column hugs one edge, a smaller row the other.
+    assert_ne!(default_path, left_path);
+    assert!(
+        left_path[1] == (0, 1),
+        "preferring a smaller column should step down first, got {:?}",
+        left_path[1]
+    );
+    assert!(
+        top_path[1] == (1, 0),
+        "preferring a smaller row should step across first, got {:?}",
+        top_path[1]
+    );
+}
+
+/// The tie-break decides how much of the graph is looked at, which is the reason to care.
+#[test]
+fn the_tie_break_changes_how_much_is_expanded() {
+    let goal = (SIDE - 1, SIDE - 1);
+
+    let count = |heuristic: &dyn Fn(&(u64, u64)) -> u64| {
+        let expansions = Cell::new(0u32);
+        let counted = |n: &(u64, u64)| {
+            expansions.set(expansions.get() + 1);
+            grid(n)
+        };
+        let (_, cost) = astar(&(0, 0), counted, |n| heuristic(n), |&n| n == goal).expect("no path");
+        assert_eq!(cost, STEP * 2 * (SIDE - 1), "the path must stay optimal");
+        expansions.get()
+    };
+
+    // The default prefers the node furthest from the start among equals, which walks straight
+    // at the goal. Forcing the opposite preference is admissible and still optimal, but it
+    // spreads the search over the whole grid instead.
+    let default_expansions = count(&distance);
+    let reversed = count(&|n| (distance(n) / STEP) * (STEP - 1));
+
+    assert!(
+        reversed > default_expansions * 4,
+        "expected the reversed tie-break to expand far more, got {reversed} against \
+         {default_expansions}"
+    );
+}
+
+/// `idastar` explores successors of equal estimated cost in the order they were given, so the
+/// caller decides simply by yielding the preferred one first.
+#[test]
+fn idastar_follows_the_order_successors_are_given_in() {
+    // Two routes of identical cost, so their estimates tie the whole way down.
+    let routes = |reversed: bool| {
+        move |&n: &char| {
+            let mut out: Vec<(char, u32)> = match n {
+                'S' => vec![('A', 2), ('B', 2)],
+                'A' | 'B' => vec![('G', 2)],
+                _ => vec![],
+            };
+            if reversed {
+                out.reverse();
+            }
+            out
+        }
+    };
+
+    let (through_a, cost) =
+        idastar(&'S', routes(false), |_| 0, |&n| n == 'G').expect("no path found");
+    let (through_b, reversed_cost) =
+        idastar(&'S', routes(true), |_| 0, |&n| n == 'G').expect("no path found");
+
+    assert_eq!(through_a, vec!['S', 'A', 'G']);
+    assert_eq!(through_b, vec!['S', 'B', 'G']);
+    assert_eq!(cost, reversed_cost);
+}


### PR DESCRIPTION
Closes #681.

You asked in that thread how tie-breaking could be supported without modifying the public API of `astar`/`idastar`. It turns out it can be, and mostly already is — this makes it real and documented rather than accidental. **No public API changes.**

## Ties are worth caring about

Expansion counts on a 120x120 grid, with the same optimal path returned every time:

| tie-break | open grid | 20% blocked |
| --- | --- | --- |
| current behaviour (decreasing cost from the start) | **238** | **1046** |
| `h * (1 + 1/1024)` | 238 | 1046 |
| cross-product | 238 | 1051 |
| increasing cost from the start | 14399 | 7016 |

So @cwoodhayes is right that the choice is significant — up to 60x here. Worth saying plainly, though: the current behaviour is already the one usually recommended, and it beat every alternative I tried. The value of choosing is in the unusual case, not the common one.

## `astar` already lets the caller decide

Every row of that table was produced without touching the library, purely through `heuristic`. The queue orders by estimated cost and then prefers the larger cost from the start; the caller controls both the cost type's `Ord` and `h`, so any preference that is a function of `g`, `h` or the node can be folded into the heuristic by giving costs room beneath a single step:

```rust
const STEP: u64 = 1024;            // one move, 1023 units of room beneath it
let keep_left = |n: &(u64, u64)| distance(n) + n.0;
```

A term smaller than a step reorders the queue but can never outweigh a real difference in cost, so the path stays optimal. That is not something a reader would guess, so it is now a `# Tie-breaking` section on `astar` with a runnable example.

## `idastar` needed one word

It sorted successors of equal estimated cost with `sort_unstable_by_key`. The caller's order does survive that today — but only because the sort falls back to insertion sort on short slices, which happens to be stable. Nothing promises it.

```diff
-        neighbs.sort_unstable_by_key(|(_, _, c1)| *c1);
+        neighbs.sort_by_key(|(_, _, c1)| *c1);
```

Now the order `successors` yields them in is the tie-break by contract. I measured it: **0.011 ms per run either way** on a 65x65 grid, because both are insertion sort at these lengths.

## Tests

`tests/tiebreak.rs`: a sub-step term selects between equal-cost paths without changing their cost; the tie-break measurably changes how much of the graph is expanded while the path stays optimal; and reversing the order `idastar` is given its successors reverses the path it returns.

295 tests pass, clippy and rustfmt clean.

## Worth your judgement

This answers the request by documenting a technique rather than adding a parameter. If you would rather have an explicit tie-break argument, that needs either a new function or a breaking change, and I did not want to presume either. @cwoodhayes offered to write a PR — if the documented approach does not cover the case that prompted the issue, it would be useful to hear what does.
