### PR TITLE
fix: panic instead of returning a wrapped path cost

### DIFF
--- a/src/directed/astar.rs
+++ b/src/directed/astar.rs
@@ -1,6 +1,7 @@
 //! Compute a shortest path (or all shorted paths) using the [A* search
 //! algorithm](https://en.wikipedia.org/wiki/A*_search_algorithm).
 
+use crate::add_costs;
 use indexmap::map::Entry::{Occupied, Vacant};
 use num_traits::Zero;
 use std::cmp::Ordering;
@@ -29,6 +30,13 @@ use crate::FxIndexMap;
 /// A node will never be included twice in the path as determined by the `Eq` relationship.
 ///
 /// The returned path comprises both the start and end node.
+///
+/// # Panics
+///
+/// This function panics if the cost of a path, or the sum of a path cost and a heuristic
+/// estimate, does not fit into `C`. Silently returning a wrapped, and therefore wrong, cost
+/// would be worse than failing loudly. If your costs can come close to the limits of the
+/// type, use a wider type, or a wrapper type whose addition saturates.
 ///
 /// # Example
 ///
@@ -77,7 +85,6 @@ use crate::FxIndexMap;
 ///                    |&p| p == GOAL);
 /// assert_eq!(result.expect("no path found").1, 4);
 /// ```
-#[expect(clippy::missing_panics_doc)]
 pub fn astar<N, C, FN, IN, FH, FS>(
     start: &N,
     mut successors: FN,
@@ -116,7 +123,7 @@ where
             successors(node)
         };
         for (successor, move_cost) in successors {
-            let new_cost = cost + move_cost;
+            let new_cost = add_costs(cost, move_cost);
             let h; // heuristic(&successor)
             let n; // index for successor
             match parents.entry(successor) {
@@ -137,7 +144,7 @@ where
             }
 
             to_see.push(SmallestCostHolder {
-                estimated_cost: new_cost + h,
+                estimated_cost: add_costs(new_cost, h),
                 cost: new_cost,
                 index: n,
             });
@@ -169,7 +176,13 @@ where
 ///
 /// Each path comprises both the start and an end node. Note that while every path shares the same
 /// start node, different paths may have different end nodes.
-#[expect(clippy::missing_panics_doc)]
+///
+/// # Panics
+///
+/// This function panics if the cost of a path, or the sum of a path cost and a heuristic
+/// estimate, does not fit into `C`. Silently returning a wrapped, and therefore wrong, cost
+/// would be worse than failing loudly. If your costs can come close to the limits of the
+/// type, use a wider type, or a wrapper type whose addition saturates.
 pub fn astar_bag<N, C, FN, IN, FH, FS>(
     start: &N,
     mut successors: FN,
@@ -223,7 +236,7 @@ where
             successors(node)
         };
         for (successor, move_cost) in successors {
-            let new_cost = cost + move_cost;
+            let new_cost = add_costs(cost, move_cost);
             let h; // heuristic(&successor)
             let n; // index for successor
             match parents.entry(successor) {
@@ -255,7 +268,7 @@ where
             }
 
             to_see.push(SmallestCostHolder {
-                estimated_cost: new_cost + h,
+                estimated_cost: add_costs(new_cost, h),
                 cost: new_cost,
                 index: n,
             });
@@ -289,6 +302,13 @@ where
 /// ### Warning
 ///
 /// The number of results with the same value might be very large in some graphs. Use with caution.
+///
+/// # Panics
+///
+/// This function panics if the cost of a path, or the sum of a path cost and a heuristic
+/// estimate, does not fit into `C`. Silently returning a wrapped, and therefore wrong, cost
+/// would be worse than failing loudly. If your costs can come close to the limits of the
+/// type, use a wider type, or a wrapper type whose addition saturates.
 pub fn astar_bag_collect<N, C, FN, IN, FH, FS>(
     start: &N,
     successors: FN,

--- a/src/directed/dijkstra.rs
+++ b/src/directed/dijkstra.rs
@@ -3,6 +3,7 @@
 
 use super::reverse_path;
 use crate::FxIndexMap;
+use crate::add_costs;
 use indexmap::map::Entry::{Occupied, Vacant};
 use num_traits::Zero;
 use std::cmp::Ordering;
@@ -25,6 +26,13 @@ use std::hash::Hash;
 /// A node will never be included twice in the path as determined by the `Eq` relationship.
 ///
 /// The returned path comprises both the start and end node.
+///
+/// # Panics
+///
+/// This function panics if the cost of a path does not fit into `C`. Silently returning a
+/// wrapped, and therefore wrong, cost would be worse than failing loudly. If your costs can
+/// come close to the limits of the type, use a wider type, or a wrapper type whose addition
+/// saturates.
 ///
 /// # Example
 ///
@@ -129,6 +137,13 @@ where
 ///
 /// The returned path comprises both the start and end node.
 ///
+/// # Panics
+///
+/// This function panics if the cost of a path does not fit into `C`. Silently returning a
+/// wrapped, and therefore wrong, cost would be worse than failing loudly. If your costs can
+/// come close to the limits of the type, use a wider type, or a wrapper type whose addition
+/// saturates.
+///
 /// # Example
 ///
 /// We search the shortest path on a chess board to go from (1, 1) to (4, 6) doing only knight
@@ -147,7 +162,6 @@ where
 /// let result = dijkstra_bidirectional(&(1, 1), &(4, 6), neighbours, neighbours);
 /// assert_eq!(result.expect("no path found").1, 4);
 /// ```
-#[expect(clippy::missing_panics_doc)]
 pub fn dijkstra_bidirectional<N, C, FS, IS, FP, IP>(
     start: &N,
     end: &N,
@@ -200,7 +214,7 @@ where
         };
         // Any path the two searches have not joined up yet costs at least as much as the sum of
         // the two frontier costs, so once that reaches the best known path nothing better is left.
-        if best.is_some_and(|(cost, ..)| forward_min.cost + backward_min.cost >= cost) {
+        if best.is_some_and(|(cost, ..)| add_costs(forward_min.cost, backward_min.cost) >= cost) {
             break;
         }
         expand_bidirectional(
@@ -283,7 +297,7 @@ fn expand_bidirectional<N, C, FN, IN>(
         neighbours(node)
     };
     for (neighbour, move_cost) in neighbours {
-        let new_cost = cost + move_cost;
+        let new_cost = add_costs(cost, move_cost);
         let n;
         match parents.entry(neighbour) {
             Vacant(e) => {
@@ -307,7 +321,7 @@ fn expand_bidirectional<N, C, FN, IN>(
         // complete path; keep it if it is the cheapest one seen so far.
         let neighbour = parents.get_index(n).unwrap().0;
         if let Some((opposite_index, _, &(_, opposite_cost))) = opposite.get_full(neighbour) {
-            let total = new_cost + opposite_cost;
+            let total = add_costs(new_cost, opposite_cost);
             if best.is_none_or(|(current, ..)| total < current) {
                 *best = Some(if is_forward {
                     (total, n, opposite_index)
@@ -333,6 +347,13 @@ fn expand_bidirectional<N, C, FN, IN>(
 ///
 /// The [`build_path`] function can be used to build a full path from the starting point to one
 /// of the reachable targets.
+///
+/// # Panics
+///
+/// This function panics if the cost of a path does not fit into `C`. Silently returning a
+/// wrapped, and therefore wrong, cost would be worse than failing loudly. If your costs can
+/// come close to the limits of the type, use a wider type, or a wrapper type whose addition
+/// saturates.
 ///
 /// # Example
 ///
@@ -383,7 +404,13 @@ where
 ///
 /// The [`build_path`] function can be used to build a full path from the starting point to one
 /// of the reachable targets.
-#[expect(clippy::missing_panics_doc)]
+///
+/// # Panics
+///
+/// This function panics if the cost of a path does not fit into `C`. Silently returning a
+/// wrapped, and therefore wrong, cost would be worse than failing loudly. If your costs can
+/// come close to the limits of the type, use a wider type, or a wrapper type whose addition
+/// saturates.
 pub fn dijkstra_partial<N, C, FN, IN, FS>(
     start: &N,
     mut successors: FN,
@@ -443,7 +470,7 @@ where
             successors(node)
         };
         for (successor, move_cost) in successors {
-            let new_cost = cost + move_cost;
+            let new_cost = add_costs(cost, move_cost);
             let n;
             match parents.entry(successor) {
                 Vacant(e) => {
@@ -585,7 +612,7 @@ where
                 (self.successors)(node)
             };
             for (successor, move_cost) in successors {
-                let new_cost = cost + move_cost;
+                let new_cost = add_costs(cost, move_cost);
                 let n;
                 match self.parents.entry(successor) {
                     Vacant(e) => {
@@ -620,6 +647,13 @@ where
 ///
 /// The `successors` function receives the current node, and returns
 /// an iterator of successors associated with their move cost.
+///
+/// # Panics
+///
+/// This function panics if the cost of a path does not fit into `C`. Silently returning a
+/// wrapped, and therefore wrong, cost would be worse than failing loudly. If your costs can
+/// come close to the limits of the type, use a wider type, or a wrapper type whose addition
+/// saturates.
 pub fn dijkstra_reach<N, C, FN, IN>(start: &N, successors: FN) -> DijkstraReachable<N, C, FN>
 where
     N: Eq + Hash + Clone,

--- a/src/directed/fringe.rs
+++ b/src/directed/fringe.rs
@@ -3,6 +3,7 @@
 
 use super::reverse_path;
 use crate::FxIndexMap;
+use crate::add_costs;
 use indexmap::map::Entry::{Occupied, Vacant};
 use num_traits::{Bounded, Zero};
 use std::collections::VecDeque;
@@ -27,6 +28,13 @@ use std::mem;
 /// A node will never be included twice in the path as determined by the `Eq` relationship.
 ///
 /// The returned path comprises both the start and end node.
+///
+/// # Panics
+///
+/// This function panics if the cost of a path, or the sum of a path cost and a heuristic
+/// estimate, does not fit into `C`. Silently returning a wrapped, and therefore wrong, cost
+/// would be worse than failing loudly. If your costs can come close to the limits of the
+/// type, use a wider type, or a wrapper type whose addition saturates.
 ///
 /// # Example
 ///
@@ -77,7 +85,6 @@ use std::mem;
 ///                     |&p| p == GOAL);
 /// assert_eq!(result.expect("no path found").1, 4);
 /// ```
-#[expect(clippy::missing_panics_doc)]
 pub fn fringe<N, C, FN, IN, FH, FS>(
     start: &N,
     mut successors: FN,
@@ -117,7 +124,7 @@ where
             }
             let (g, successors) = {
                 let (node, &(_, g)) = parents.get_index(i).unwrap(); // Cannot fail
-                let f = g + heuristic(node);
+                let f = add_costs(g, heuristic(node));
                 if f > flimit {
                     if f < fmin {
                         fmin = f;
@@ -132,7 +139,7 @@ where
                 (g, successors(node))
             };
             for (successor, cost) in successors {
-                let g_successor = g + cost;
+                let g_successor = add_costs(g, cost);
                 let n; // index for successor
                 match parents.entry(successor) {
                     Vacant(e) => {

--- a/src/directed/idastar.rs
+++ b/src/directed/idastar.rs
@@ -2,6 +2,7 @@
 //! algorithm](https://en.wikipedia.org/wiki/Iterative_deepening_A*).
 
 use crate::FxIndexSet;
+use crate::add_costs;
 use num_traits::Zero;
 use std::{hash::Hash, ops::ControlFlow};
 
@@ -23,6 +24,13 @@ use std::{hash::Hash, ops::ControlFlow};
 /// A node will never be included twice in the path as determined by the `Eq` relationship.
 ///
 /// The returned path comprises both the start and end node.
+///
+/// # Panics
+///
+/// This function panics if the cost of a path, or the sum of a path cost and a heuristic
+/// estimate, does not fit into `C`. Silently returning a wrapped, and therefore wrong, cost
+/// would be worse than failing loudly. If your costs can come close to the limits of the
+/// type, use a wider type, or a wrapper type whose addition saturates.
 ///
 /// # Example
 ///
@@ -124,7 +132,7 @@ where
 {
     let neighbs = {
         let start = &path[path.len() - 1];
-        let f = cost + heuristic(start);
+        let f = add_costs(cost, heuristic(start));
         if f > bound {
             return ControlFlow::Continue(Some(f));
         }
@@ -136,7 +144,7 @@ where
             .filter_map(|(n, c)| {
                 (!path.contains(&n)).then(|| {
                     let h = heuristic(&n);
-                    (n, c, c + h)
+                    (n, c, add_costs(c, h))
                 })
             })
             .collect::<Vec<_>>();
@@ -146,7 +154,14 @@ where
     let mut min = None;
     for (node, extra, _) in neighbs {
         let (idx, _) = path.insert_full(node);
-        match search(path, cost + extra, bound, successors, heuristic, success)? {
+        match search(
+            path,
+            add_costs(cost, extra),
+            bound,
+            successors,
+            heuristic,
+            success,
+        )? {
             Some(m) if min.is_none_or(|n| n >= m) => min = Some(m),
             _ => (),
         }

--- a/src/directed/yen.rs
+++ b/src/directed/yen.rs
@@ -1,5 +1,6 @@
 //! Compute k-shortest paths using [Yen's search
 //! algorithm](https://en.wikipedia.org/wiki/Yen%27s_algorithm).
+use crate::add_costs;
 use num_traits::Zero;
 use rustc_hash::FxHashSet;
 use std::cmp::Ordering;
@@ -60,6 +61,13 @@ where
 /// The returned paths include both the start and the end node and are ordered by their costs
 /// starting with the lowest cost. If there exist less paths than requested, only the existing
 /// ones (if any) are returned.
+///
+/// # Panics
+///
+/// This function panics if the cost of a path does not fit into `C`. Silently returning a
+/// wrapped, and therefore wrong, cost would be worse than failing loudly. If your costs can
+/// come close to the limits of the type, use a wider type, or a wrapper type whose addition
+/// saturates.
 ///
 /// # Example
 /// We will search the 3 shortest paths from node C to node H. See
@@ -178,7 +186,7 @@ where
                     // Build a min-heap
                     k_routes.push(Reverse(Path {
                         nodes,
-                        cost: root_costs[i] + spur_cost,
+                        cost: add_costs(root_costs[i], spur_cost),
                         spur_index: i,
                     }));
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,42 @@ use std::hash::BuildHasherDefault;
 type FxIndexMap<K, V> = IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 type FxIndexSet<K> = IndexSet<K, BuildHasherDefault<FxHasher>>;
 
+/// Report a cost addition that wrapped.
+///
+/// Kept out of line and marked cold so that [`add_costs`] stays small enough to inline: the
+/// check sits in the innermost loop of every cost-based search, and a panic formatted inline
+/// there would cost more than the check itself.
+#[cold]
+#[inline(never)]
+fn cost_overflow() -> ! {
+    panic!("cost overflow: the total path cost does not fit in the cost type");
+}
+
+/// Add two costs, panicking if the sum wrapped around instead of growing.
+///
+/// Cost types are only required to be `Zero + Ord + Copy`, so `checked_add` is not available
+/// here and requiring `num_traits::CheckedAdd` would be a breaking change. Costs are however
+/// required to be non-negative, and that is enough: adding a non-negative value can never
+/// produce a smaller one, so a sum that compares less than the value it was added to must
+/// have wrapped.
+///
+/// This makes release builds agree with debug builds, which already panic on overflow, rather
+/// than silently returning a wrapped and therefore wrong cost. Cost types that saturate, and
+/// floating point costs which reach infinity rather than wrapping, compare greater and are
+/// left untouched. Negative addends are left alone as well, since they are outside what these
+/// algorithms support and this check cannot say anything useful about them.
+#[inline]
+pub(crate) fn add_costs<C>(a: C, b: C) -> C
+where
+    C: num_traits::Zero + Ord + Copy,
+{
+    let sum = a + b;
+    if sum < a && b >= C::zero() {
+        cost_overflow();
+    }
+    sum
+}
+
 /// Export all public functions and structures for an easy access.
 pub mod prelude {
     pub use crate::directed::astar::*;

--- a/tests/cost_overflow.rs
+++ b/tests/cost_overflow.rs
@@ -1,0 +1,152 @@
+//! A path cost that does not fit in the cost type must not be reported as if it did.
+//!
+//! Debug builds have always panicked on such an addition. Release builds used to wrap, which
+//! turned an impossible-to-represent cost into a small plausible-looking one. These tests pin
+//! the behaviour down in both profiles.
+
+use pathfinding::prelude::*;
+
+// The panic message differs by profile: debug builds trip the built-in "attempt to add with
+// overflow" inside `+` before the library's own check runs, while release builds reach the
+// check and report "cost overflow". Both contain "overflow", which is what these tests pin.
+
+/// Three of these do not fit in a `u32`: the wrapped sum would be 2147483645.
+const HUGE: u32 = u32::MAX / 2;
+
+// The successor and success callbacks are handed a reference by the search functions.
+#[expect(clippy::trivially_copy_pass_by_ref)]
+fn expensive(n: &u32) -> Vec<(u32, u32)> {
+    vec![(n + 1, HUGE)]
+}
+
+// The successor and success callbacks are handed a reference by the search functions.
+#[expect(clippy::trivially_copy_pass_by_ref)]
+fn cheap(n: &u32) -> Vec<(u32, u32)> {
+    vec![(n + 1, 10)]
+}
+
+// The successor and success callbacks are handed a reference by the search functions.
+#[expect(clippy::trivially_copy_pass_by_ref)]
+const fn at_three(n: &u32) -> bool {
+    *n == 3
+}
+
+#[test]
+#[should_panic(expected = "overflow")]
+fn astar_refuses_to_wrap() {
+    astar(&0, expensive, |_| 0, at_three);
+}
+
+#[test]
+#[should_panic(expected = "overflow")]
+fn astar_bag_refuses_to_wrap() {
+    astar_bag(&0, expensive, |_| 0, at_three);
+}
+
+#[test]
+#[should_panic(expected = "overflow")]
+fn dijkstra_refuses_to_wrap() {
+    dijkstra(&0, expensive, at_three);
+}
+
+#[test]
+#[should_panic(expected = "overflow")]
+fn dijkstra_all_refuses_to_wrap() {
+    dijkstra_all(&0, |n: &u32| if *n < 4 { expensive(n) } else { vec![] });
+}
+
+#[test]
+#[should_panic(expected = "overflow")]
+fn dijkstra_reach_refuses_to_wrap() {
+    dijkstra_reach(&0, |n: &u32| if *n < 4 { expensive(n) } else { vec![] }).for_each(drop);
+}
+
+#[test]
+#[should_panic(expected = "overflow")]
+fn fringe_refuses_to_wrap() {
+    fringe(&0, expensive, |_| 0, at_three);
+}
+
+#[test]
+#[should_panic(expected = "overflow")]
+fn idastar_refuses_to_wrap() {
+    idastar(&0, expensive, |_| 0, at_three);
+}
+
+#[test]
+#[should_panic(expected = "overflow")]
+fn yen_refuses_to_wrap() {
+    yen(&0, expensive, at_three, 2);
+}
+
+/// The reported case: the path cost is representable, but adding the heuristic is not.
+#[test]
+#[should_panic(expected = "overflow")]
+fn astar_checks_the_heuristic_too() {
+    astar(&0, cheap, |_| u32::MAX, at_three);
+}
+
+#[test]
+#[should_panic(expected = "overflow")]
+fn fringe_checks_the_heuristic_too() {
+    fringe(&0, cheap, |_| u32::MAX, at_three);
+}
+
+#[test]
+#[should_panic(expected = "overflow")]
+fn idastar_checks_the_heuristic_too() {
+    idastar(&0, cheap, |_| u32::MAX, at_three);
+}
+
+/// A cost type whose addition saturates is the documented way to opt out of the panic. It
+/// must keep working: a saturating sum never compares smaller, so it never trips the check.
+mod saturating {
+    use super::{HUGE, at_three};
+    use pathfinding::prelude::*;
+
+    // The panic message differs by profile: debug builds trip the built-in "attempt to add with
+    // overflow" inside `+` before the library's own check runs, while release builds reach the
+    // check and report "cost overflow". Both contain "overflow", which is what these tests pin.
+
+    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+    struct Saturating(u32);
+
+    impl std::ops::Add for Saturating {
+        type Output = Self;
+        fn add(self, other: Self) -> Self {
+            Self(self.0.saturating_add(other.0))
+        }
+    }
+
+    impl num_traits::Zero for Saturating {
+        fn zero() -> Self {
+            Self(0)
+        }
+        fn is_zero(&self) -> bool {
+            self.0 == 0
+        }
+    }
+
+    #[test]
+    fn a_saturating_cost_type_does_not_panic() {
+        let (path, cost) = astar(
+            &0,
+            |n: &u32| vec![(n + 1, Saturating(HUGE))],
+            |_| Saturating(0),
+            at_three,
+        )
+        .unwrap();
+        assert_eq!(path, vec![0, 1, 2, 3]);
+        assert_eq!(cost, Saturating(u32::MAX));
+    }
+}
+
+/// Costs that fit must be entirely unaffected.
+#[test]
+fn ordinary_costs_are_untouched() {
+    assert_eq!(astar(&0, cheap, |_| 0, at_three).unwrap().1, 30);
+    assert_eq!(dijkstra(&0, cheap, at_three).unwrap().1, 30);
+    assert_eq!(fringe(&0, cheap, |_| 0, at_three).unwrap().1, 30);
+    assert_eq!(idastar(&0, cheap, |_| 0, at_three).unwrap().1, 30);
+    assert_eq!(yen(&0, cheap, at_three, 1)[0].1, 30);
+}


### PR DESCRIPTION
Fixes #598.

Adding costs can overflow the cost type. Debug builds panic; release builds wrap and return a small, plausible-looking, wrong cost. Three edges of `u32::MAX / 2` currently give 2,147,483,645, which is `6442450941 mod 2^32`, and nothing in the result says so.

## Approach

The blocker recorded in the issue was that checked arithmetic would need `num_traits::CheckedAdd` or `SaturatingAdd` on `C`, which would be breaking. It turns out the existing bounds are enough: `C` is already `Zero + Ord + Copy`, `num_traits::Zero` implies `Add<Output = Self>`, and costs are required to be non-negative. Adding a non-negative value can never produce a smaller one, so a wrapped sum is detectable by comparison:

```rust
let sum = a + b;
if sum < a && b >= C::zero() {
    cost_overflow();
}
sum
```

No new trait bound, so this can ship in a patch release. Release builds now agree with debug builds rather than returning a wrapped cost.

The panic lives in a separate `#[cold] #[inline(never)]` function so that `add_costs` stays small enough to inline.

## What is left alone

- Cost types whose addition saturates never produce a smaller sum, so they never trip the check. The workaround suggested in the issue keeps working, and there is a test for it.
- Floating point costs reach infinity rather than wrapping, so they compare greater and are untouched.
- Negative addends are skipped, since they are outside what these algorithms support and the check cannot say anything useful about them.

## Covered

`astar`, `astar_bag`, `astar_bag_collect`, `dijkstra`, `dijkstra_bidirectional`, `dijkstra_all`, `dijkstra_partial`, `dijkstra_reach`, `fringe`, `idastar`, `yen`. Each gains the `# Panics` section requested in the issue.

Adding those sections made five `#[expect(clippy::missing_panics_doc)]` attributes unfulfilled, so they are removed here. Those functions could always panic; the lint had been silenced rather than satisfied. Worth noting that clippy does not catch this class on its own, since `missing_panics_doc` does not trace through a call into a private helper.

## Tests

`tests/cost_overflow.rs` covers every affected entry point, the heuristic addition specifically (the case in the issue), the saturating-cost-type workaround, and that ordinary costs are unchanged.

Against current `main` they fail in release, which is where the bug is: 11 of 13 fail, the two that pass being the two meant to behave identically either way. In debug they pass against `main` too, because debug builds already panicked there, which is the behaviour this PR extends to release. The `should_panic` expectations therefore match on `overflow` rather than the exact message, since debug trips the built-in `attempt to add with overflow` inside `+` before the library's own check is reached.

## Cost

This puts a branch in the innermost loop, so it is not free, but it is cheap.

Instruction counts, comparing `main` against this branch. These use the corrected benchmarks from #835, because the ones currently on `main` do not measure the work they run (#833) and gave a badly misleading answer here; see the note below.

| benchmark | uses costs | main | this branch | change |
|---|---|---|---|---|
| `corner_to_corner_idastar` | yes | 153,194 | 158,177 | +3.3% |
| `no_path_fringe` | yes | 2,907,008 | 2,936,349 | +1.0% |
| `no_path_dijkstra` | yes | 3,033,622 | 3,054,515 | +0.7% |
| `corner_to_corner_dijkstra` | yes | 3,059,458 | 3,080,348 | +0.7% |
| `corner_to_corner_astar` | yes | 152,818 | 153,796 | +0.6% |
| `corner_to_corner_fringe` | yes | 118,850 | 119,578 | +0.6% |
| `no_path_astar` | yes | 3,517,679 | 3,537,909 | +0.6% |
| `corner_to_corner_bfs` | no (control) | 2,636,674 | 2,636,676 | 0.0% |
| `no_path_bfs` | no (control) | 2,543,357 | 2,543,360 | 0.0% |
| `corner_to_corner_bfs_bidirectional` | no (control) | 2,797,635 | 2,797,664 | 0.0% |
| `no_path_bfs_bidirectional` | no (control) | 2,662,484 | 2,662,523 | 0.0% |
| `corner_to_corner_iddfs` | no (control) | 3,790,714 | 3,790,713 | 0.0% |

Every algorithm that adds costs pays between 0.6% and 3.3%. Five of the six that do not add costs are unchanged to the instruction. The sixth, `dfs`, moves -6.7% despite not being touched, which is codegen drift and the one blemish on an otherwise very clean set.

Wall clock shows no measurable change: on a 256x256 grid, fastest of 40 runs over 5 alternated rounds, `dijkstra` came out 5.4% faster with the check while `bfs`, which uses no costs and cannot be affected, came out 5.8% faster in the same run, so that is layout rather than the check.

### A correction

An earlier version of this description reported +18.6% on `corner_to_corner_dijkstra`. That figure was an artefact of #833. With the benchmarks as they stand on `main`, `dijkstra` is inlined wholesale into the benchmark harness, and adding a branch to its inner loop upends that inlining, so the comparison measured the harness rather than the change. With the search behind a call the optimiser cannot see through, which is also closer to how callers actually invoke it, the cost is 0.7%. I am sorry for the noise; the number stood for a few hours.

Measurements on Windows 11, Intel Core Ultra 7 265K, 64 GB RAM; instruction counts from WSL2 Ubuntu 24.04 on the same machine with valgrind 3.22.0 and iai-callgrind 0.16.1.
