### PR TITLE
bench: make the iai benchmarks measure the work they run

### DIFF
--- a/benches/iai_algos.rs
+++ b/benches/iai_algos.rs
@@ -1,5 +1,16 @@
+//! Instruction-count benchmarks for the search algorithms.
+//!
+//! Each search runs inside an `#[inline(never)]` helper whose result is returned from the
+//! benchmark. Both halves matter. Callgrind only counts instructions while collection is
+//! toggled on around the benchmark function, so a search that gets inlined into the harness
+//! and folded away is reported as a few hundred instructions rather than a few million; and
+//! because that depends on inlining, it changes with unrelated edits and turns into a
+//! spurious regression in the CI comparison. Keeping the work behind a call the optimiser
+//! cannot see through, and consuming the result, keeps the measurement honest.
+
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use pathfinding::prelude::{astar, bfs, bfs_bidirectional, dfs, dijkstra, fringe, idastar, iddfs};
+use std::hint::black_box;
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct Pt {
@@ -36,148 +47,174 @@ fn successors(pt: &Pt) -> Vec<Pt> {
     ret
 }
 
+#[inline]
+fn weighted(pt: &Pt) -> impl Iterator<Item = (Pt, usize)> + use<> {
+    successors(pt).into_iter().map(|n| (n, 1))
+}
+
+const fn at_corner(n: &Pt) -> bool {
+    n.x == 64 && n.y == 64
+}
+
+const fn never(_: &Pt) -> bool {
+    false
+}
+
+const fn at_five(n: &Pt) -> bool {
+    n.x == 5 && n.y == 5
+}
+
+const fn one(_: &Pt) -> usize {
+    1
+}
+
+type Path = Option<(Vec<Pt>, usize)>;
+
+#[inline(never)]
+fn run_astar(start: &Pt, success: fn(&Pt) -> bool, heuristic: fn(&Pt) -> usize) -> Path {
+    astar(start, weighted, heuristic, success)
+}
+
+#[inline(never)]
+fn run_dijkstra(start: &Pt, success: fn(&Pt) -> bool) -> Path {
+    dijkstra(start, weighted, success)
+}
+
+#[inline(never)]
+fn run_fringe(start: &Pt, success: fn(&Pt) -> bool, heuristic: fn(&Pt) -> usize) -> Path {
+    fringe(start, weighted, heuristic, success)
+}
+
+#[inline(never)]
+fn run_idastar(start: &Pt, success: fn(&Pt) -> bool) -> Path {
+    idastar(start, weighted, Pt::heuristic, success)
+}
+
+#[inline(never)]
+fn run_bfs(start: &Pt, success: fn(&Pt) -> bool) -> Option<Vec<Pt>> {
+    bfs(start, successors, success)
+}
+
+#[inline(never)]
+fn run_dfs(start: Pt, success: fn(&Pt) -> bool) -> Option<Vec<Pt>> {
+    dfs(start, successors, success)
+}
+
+#[inline(never)]
+fn run_iddfs(start: Pt, success: fn(&Pt) -> bool) -> Option<Vec<Pt>> {
+    iddfs(start, successors, success)
+}
+
+#[inline(never)]
+fn run_bfs_bidirectional(start: &Pt, end: &Pt) -> Option<Vec<Pt>> {
+    bfs_bidirectional(start, end, successors, successors)
+}
+
+/// The no-path case searches backwards from an unreachable node that has no successors.
+#[inline(never)]
+fn run_bfs_bidirectional_no_path(start: &Pt, end: &Pt) -> Option<Vec<Pt>> {
+    bfs_bidirectional(start, end, successors, |_| vec![])
+}
+
 #[library_benchmark]
-fn corner_to_corner_astar() {
-    assert_ne!(
-        astar(
-            &Pt::new(0, 0),
-            |n| successors(n).into_iter().map(|n| (n, 1)),
-            Pt::heuristic,
-            |n| n.x == 64 && n.y == 64,
-        ),
-        None
+fn corner_to_corner_astar() -> Path {
+    let path = run_astar(&black_box(Pt::new(0, 0)), at_corner, Pt::heuristic);
+    assert!(path.is_some());
+    path
+}
+
+#[library_benchmark]
+fn corner_to_corner_bfs() -> Option<Vec<Pt>> {
+    let path = run_bfs(&black_box(Pt::new(0, 0)), at_corner);
+    assert!(path.is_some());
+    path
+}
+
+#[library_benchmark]
+fn corner_to_corner_bfs_bidirectional() -> Option<Vec<Pt>> {
+    let path = run_bfs_bidirectional(&black_box(Pt::new(0, 0)), &black_box(Pt::new(64, 64)));
+    assert!(path.is_some());
+    path
+}
+
+#[library_benchmark]
+fn corner_to_corner_dfs() -> Option<Vec<Pt>> {
+    let path = run_dfs(black_box(Pt::new(0, 0)), at_corner);
+    assert!(path.is_some());
+    path
+}
+
+#[library_benchmark]
+fn corner_to_corner_dijkstra() -> Path {
+    let path = run_dijkstra(&black_box(Pt::new(0, 0)), at_corner);
+    assert!(path.is_some());
+    path
+}
+
+#[library_benchmark]
+fn corner_to_corner_fringe() -> Path {
+    let path = run_fringe(&black_box(Pt::new(0, 0)), at_corner, Pt::heuristic);
+    assert!(path.is_some());
+    path
+}
+
+#[library_benchmark]
+fn corner_to_corner_idastar() -> Path {
+    let path = run_idastar(&black_box(Pt::new(0, 0)), at_corner);
+    assert!(path.is_some());
+    path
+}
+
+#[library_benchmark]
+fn corner_to_corner_iddfs() -> Option<Vec<Pt>> {
+    let path = run_iddfs(black_box(Pt::new(0, 0)), at_five);
+    assert!(path.is_some());
+    path
+}
+
+#[library_benchmark]
+fn no_path_astar() -> Path {
+    let path = run_astar(&black_box(Pt::new(2, 3)), never, one);
+    assert!(path.is_none());
+    path
+}
+
+#[library_benchmark]
+fn no_path_bfs() -> Option<Vec<Pt>> {
+    let path = run_bfs(&black_box(Pt::new(2, 3)), never);
+    assert!(path.is_none());
+    path
+}
+
+#[library_benchmark]
+fn no_path_bfs_bidirectional() -> Option<Vec<Pt>> {
+    let path = run_bfs_bidirectional_no_path(
+        &black_box(Pt::new(2, 3)),
+        &black_box(Pt::new(u16::MAX, u16::MAX)),
     );
+    assert!(path.is_none());
+    path
 }
 
 #[library_benchmark]
-fn corner_to_corner_bfs() {
-    assert_ne!(
-        bfs(&Pt::new(0, 0), successors, |n| n.x == 64 && n.y == 64),
-        None
-    );
+fn no_path_dfs() -> Option<Vec<Pt>> {
+    let path = run_dfs(black_box(Pt::new(2, 3)), never);
+    assert!(path.is_none());
+    path
 }
 
 #[library_benchmark]
-fn corner_to_corner_bfs_bidirectional() {
-    assert_ne!(
-        bfs_bidirectional(&Pt::new(0, 0), &Pt::new(64, 64), successors, successors),
-        None
-    );
+fn no_path_dijkstra() -> Path {
+    let path = run_dijkstra(&black_box(Pt::new(2, 3)), never);
+    assert!(path.is_none());
+    path
 }
 
 #[library_benchmark]
-fn corner_to_corner_dfs() {
-    assert_ne!(
-        dfs(Pt::new(0, 0), successors, |n| n.x == 64 && n.y == 64),
-        None
-    );
-}
-
-#[library_benchmark]
-fn corner_to_corner_dijkstra() {
-    assert_ne!(
-        dijkstra(
-            &Pt::new(0, 0),
-            |n| successors(n).into_iter().map(|n| (n, 1)),
-            |n| n.x == 64 && n.y == 64,
-        ),
-        None
-    );
-}
-
-#[library_benchmark]
-fn corner_to_corner_fringe() {
-    assert_ne!(
-        fringe(
-            &Pt::new(0, 0),
-            |n| successors(n).into_iter().map(|n| (n, 1)),
-            Pt::heuristic,
-            |n| n.x == 64 && n.y == 64,
-        ),
-        None
-    );
-}
-
-#[library_benchmark]
-fn corner_to_corner_idastar() {
-    assert_ne!(
-        idastar(
-            &Pt::new(0, 0),
-            |n| successors(n).into_iter().map(|n| (n, 1)),
-            Pt::heuristic,
-            |n| n.x == 64 && n.y == 64,
-        ),
-        None
-    );
-}
-
-#[library_benchmark]
-fn corner_to_corner_iddfs() {
-    assert_ne!(
-        iddfs(Pt::new(0, 0), successors, |n| n.x == 5 && n.y == 5),
-        None
-    );
-}
-
-#[library_benchmark]
-fn no_path_astar() {
-    assert_eq!(
-        astar(
-            &Pt::new(2, 3),
-            |n| successors(n).into_iter().map(|n| (n, 1)),
-            |_| 1,
-            |_| false,
-        ),
-        None
-    );
-}
-
-#[library_benchmark]
-fn no_path_bfs() {
-    assert_eq!(bfs(&Pt::new(2, 3), successors, |_| false), None);
-}
-
-#[library_benchmark]
-fn no_path_bfs_bidirectional() {
-    assert_eq!(
-        bfs_bidirectional(
-            &Pt::new(2, 3),
-            &Pt::new(u16::MAX, u16::MAX),
-            successors,
-            |_| vec![]
-        ),
-        None
-    );
-}
-
-#[library_benchmark]
-fn no_path_dfs() {
-    assert_eq!(dfs(Pt::new(2, 3), successors, |_| false), None);
-}
-
-#[library_benchmark]
-fn no_path_dijkstra() {
-    assert_eq!(
-        dijkstra(
-            &Pt::new(2, 3),
-            |n| successors(n).into_iter().map(|n| (n, 1)),
-            |_| false,
-        ),
-        None
-    );
-}
-
-#[library_benchmark]
-fn no_path_fringe() {
-    assert_eq!(
-        fringe(
-            &Pt::new(2, 3),
-            |n| successors(n).into_iter().map(|n| (n, 1)),
-            |_| 1,
-            |_| false,
-        ),
-        None
-    );
+fn no_path_fringe() -> Path {
+    let path = run_fringe(&black_box(Pt::new(2, 3)), never, one);
+    assert!(path.is_none());
+    path
 }
 
 library_benchmark_group!(


### PR DESCRIPTION
Fixes #833.

Seven of the fourteen `iai_algos` benchmarks do not measure the work they run. Callgrind only counts while collection is toggled on around the benchmark function, and a search that gets inlined into the harness and folded away falls outside that window.

## What changes

Each search moves into an `#[inline(never)]` helper, and the benchmark returns its result. The optimiser cannot see through the call, and cannot discard the value. The workloads themselves are unchanged.

## Before and after

Instructions collected, against basic blocks the process actually executed:

| benchmark | before | after | basic blocks executed |
|---|---|---|---|
| `no_path_astar` | 14 | 3,521,771 | 665,378 |
| `no_path_fringe` | 14 | 2,932,278 | 631,293 |
| `no_path_bfs_bidirectional` | 16 | 2,662,440 | 574,024 |
| `corner_to_corner_astar` | 103 | 152,879 | 91,105 |
| `corner_to_corner_fringe` | 103 | 119,670 | 89,850 |
| `corner_to_corner_dfs` | 181 | 2,677,555 | 698,052 |
| `corner_to_corner_bfs` | 248 | 2,636,515 | 603,804 |

The seven that already worked are essentially unmoved, for instance `corner_to_corner_dijkstra` 3,077,484 -> 3,063,305 and `corner_to_corner_iddfs` 3,712,137 -> 3,790,713.

`corner_to_corner_astar` and `corner_to_corner_fringe` are genuinely small, at around 150k and 120k instructions, because the Manhattan heuristic is exact on an open grid so they expand very few nodes. That is now visible rather than hidden behind a broken count.

## That it stays fixed

The point is not only that the numbers are right today, but that they stay right when the algorithms change, since that is what made the old ones flip. I applied these benchmarks on top of a branch that edits the inner loop of every cost-based search (#834) and re-ran: 0 of 14 stopped measuring.

## Why this matters beyond the numbers

`.github/workflows/iai-callgrind.yml` diffs these counts between the base branch and the PR branch and posts the result. Because which benchmarks break depends on inlining, that comparison can report an enormous change for a PR that did nothing of the sort.

This is not hypothetical. Measured against the broken benchmarks, the overflow check in #834 looked like an 18.6% instruction regression on `corner_to_corner_dijkstra`. Measured against these, it is 0.7%, with five of the six benchmarks that use no costs at exactly 0.0%. The 18.6% was the harness, not the change. I have corrected the figures on that PR.

Rejected alternatives, in case they come up: `#[inline(never)]` on the benchmark functions themselves does not compile, because the `library_benchmark` macro accepts only `bench` and `benches` attributes. Adding `black_box` around the inputs alone does not help either; the result has to be consumed as well.
