### PR TITLE
fix(prim): export from the prelude, and document MST behaviour on disconnected graphs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ pub mod prelude {
     pub use crate::undirected::cliques::*;
     pub use crate::undirected::connected_components::*;
     pub use crate::undirected::kruskal::*;
+    pub use crate::undirected::prim::*;
     pub use crate::utils::*;
 }
 

--- a/src/undirected/kruskal.rs
+++ b/src/undirected/kruskal.rs
@@ -56,6 +56,11 @@ where
 /// Find a minimum-spanning-tree. From a collection of
 /// weighted edges, return an iterator of edges forming
 /// a minimum-spanning-tree.
+///
+/// # Disconnected graphs
+///
+/// Every component is spanned, so the result is a spanning forest rather than a single tree.
+/// [`prim`](super::prim::prim) differs here, and spans only the component it starts from.
 pub fn kruskal<N, C>(edges: &[(N, N, C)]) -> impl Iterator<Item = (&N, &N, C)>
 where
     N: Hash + Eq,

--- a/src/undirected/prim.rs
+++ b/src/undirected/prim.rs
@@ -11,6 +11,25 @@ use std::hash::Hash;
 ///
 /// Edges are undirected: `(a, b, c)` and `(b, a, c)` describe the same edge, and either form
 /// may be used. The tree is grown from the first endpoint of the first edge.
+///
+/// # Disconnected graphs
+///
+/// The tree is grown outwards from one node, so only the component containing that node is
+/// spanned; edges in any other component are not returned. [`kruskal`](super::kruskal::kruskal)
+/// differs here, and returns a spanning forest covering every component.
+///
+/// ```
+/// use pathfinding::prelude::{kruskal, prim};
+///
+/// // Two components: 1-2 and 3-4.
+/// let edges = vec![(1, 2, 1), (3, 4, 1)];
+///
+/// // prim spans the component holding node 1, the first endpoint of the first edge.
+/// assert_eq!(prim(&edges), vec![(&1, &2, 1)]);
+///
+/// // kruskal spans both.
+/// assert_eq!(kruskal(&edges).count(), 2);
+/// ```
 pub fn prim<N, C>(edges: &[(N, N, C)]) -> Vec<(&N, &N, C)>
 where
     N: Hash + Eq + Ord,


### PR DESCRIPTION
Two small things about `prim`, found while looking through the library.

## `prim` is missing from the prelude

Every other algorithm is re-exported there; `prim` is not. So this does not compile:

```rust
use pathfinding::prelude::*;
let mst = prim(&edges);       // error[E0425]: cannot find function `prim` in this scope
```

and callers have to write `pathfinding::undirected::prim::prim` instead, while `kruskal`, sitting right next to it in `src/undirected/`, works from the prelude. I ran into this writing a throwaway test, which is how it turned up. One line in `src/lib.rs`.

## The two MST functions disagree on disconnected graphs, silently

```rust
let edges = vec![(1, 2, 1), (3, 4, 1)];   // two components

prim(&edges)               // [(1, 2, 1)]                -- one component
kruskal(&edges).count()    // 2                          -- both components
```

`prim` grows outwards from the first endpoint of the first edge, so it spans only that component. `kruskal` sorts all edges and unions, so it spans every component and returns a forest.

Both behaviours are reasonable, and neither is a bug. The problem is that both doc comments just say "minimum-spanning-tree", which does not distinguish them, so a caller who swaps one for the other on a disconnected graph gets a quietly different answer. This documents the difference on both sides, with a runnable example on `prim`.

No behaviour change; docs and one re-export.
